### PR TITLE
Spring RestDocs 의존성, 커스텀 스니펫과 관련 설정들을 추가한다.

### DIFF
--- a/api-letter/build.gradle
+++ b/api-letter/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     testImplementation platform('com.amazonaws:aws-java-sdk-bom:1.12.360')
     testImplementation "com.amazonaws:aws-java-sdk-s3"
     testImplementation testFixtures(project(":domain-letter"))
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage:junit-vintage-engine'
     }

--- a/api-letter/src/docs/asciidoc/index.adoc
+++ b/api-letter/src/docs/asciidoc/index.adoc
@@ -1,0 +1,11 @@
+= Letter Server REST API Documentation
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]

--- a/api-letter/src/test/java/com/seeyouletter/api_letter/ApiLetterApplicationTest.java
+++ b/api-letter/src/test/java/com/seeyouletter/api_letter/ApiLetterApplicationTest.java
@@ -6,7 +6,6 @@ class ApiLetterApplicationTest extends IntegrationTestContext {
 
     @Test
     void contextLoads() {
-
     }
 
 }

--- a/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,12 @@
+// Custom Request Fields
+|===
+|Path|Type|Required|Description
+
+{{#fields}}
+<|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===

--- a/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-headers.snippet
+++ b/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-headers.snippet
@@ -1,0 +1,11 @@
+// Custom Request Headers
+|===
+|Name|Required|Description
+
+{{#headers}}
+<|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/headers}}
+
+|===

--- a/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
+++ b/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
@@ -1,0 +1,11 @@
+// Custom Request Fields
+|===
+|Name|Required|Description
+
+{{#parameters}}
+<|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+
+|===

--- a/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
+++ b/api-letter/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
@@ -1,0 +1,12 @@
+// Custom Response Fields
+|===
+|Path|Type|Required|Description
+
+{{#fields}}
+<|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===

--- a/api-member/build.gradle
+++ b/api-member/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     testImplementation platform('com.amazonaws:aws-java-sdk-bom:1.12.360')
     testImplementation "com.amazonaws:aws-java-sdk-s3"
     testImplementation testFixtures(project(":domain-member"))
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage:junit-vintage-engine'
     }

--- a/api-member/src/docs/asciidoc/index.adoc
+++ b/api-member/src/docs/asciidoc/index.adoc
@@ -1,0 +1,11 @@
+= Member Server REST API Documentation
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]

--- a/api-member/src/test/java/com/seeyouletter/api_member/ApiMemberApplicationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/ApiMemberApplicationTest.java
@@ -1,12 +1,8 @@
 package com.seeyouletter.api_member;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles(profiles = "test")
-class ApiMemberApplicationTest {
+class ApiMemberApplicationTest extends IntegrationTestContext {
 
     @Test
     void contextLoads() {

--- a/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
@@ -1,0 +1,65 @@
+package com.seeyouletter.api_member;
+
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+@Disabled
+@Transactional
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@SpringBootTest
+@ActiveProfiles(value = "test")
+public abstract class IntegrationTestContext {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    public static final OperationRequestPreprocessor REQUEST_PREPROCESSOR;
+
+    public static final OperationResponsePreprocessor RESPONSE_PREPROCESSOR;
+
+    static {
+        REQUEST_PREPROCESSOR = createRequestPreprocessor();
+        RESPONSE_PREPROCESSOR = createResponsePreprocessor();
+    }
+
+    private static OperationRequestPreprocessor createRequestPreprocessor() {
+        return preprocessRequest(
+                removeHeaders(
+                        "X-Forwarded-Host",
+                        "X-Forwarded-Proto",
+                        CONTENT_LENGTH
+                ),
+                modifyParameters()
+                        .remove("_csrf"),
+                prettyPrint()
+        );
+    }
+
+    private static OperationResponsePreprocessor createResponsePreprocessor() {
+        return preprocessResponse(
+                prettyPrint(),
+                removeHeaders(
+                        "X-Content-Type-Options",
+                        "X-XSS-Protection",
+                        "X-Frame-Options",
+                        "Pragma",
+                        CACHE_CONTROL,
+                        EXPIRES,
+                        CONTENT_LENGTH
+                )
+        );
+    }
+
+}

--- a/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,12 @@
+// Custom Request Fields
+|===
+|Path|Type|Required|Description
+
+{{#fields}}
+<|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===

--- a/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-headers.snippet
+++ b/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-headers.snippet
@@ -1,0 +1,11 @@
+// Custom Request Headers
+|===
+|Name|Required|Description
+
+{{#headers}}
+<|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/headers}}
+
+|===

--- a/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
+++ b/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
@@ -1,0 +1,11 @@
+// Custom Request Fields
+|===
+|Name|Required|Description
+
+{{#parameters}}
+<|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+
+|===

--- a/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
+++ b/api-member/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
@@ -1,0 +1,12 @@
+// Custom Response Fields
+|===
+|Path|Type|Required|Description
+
+{{#fields}}
+<|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+<|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+<|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===


### PR DESCRIPTION
## 💌 설명

<!-- 해당 PR에 대하여 간단한 설명이 필요해요! 🙆🏻 -->

spring-restdocs-mockmvc, spring-security-test 의존성을 추가하고, e2e 테스트에서 restdocs 문서를 생성할 수 있도록 공통 테스트 컨텍스트 클래스에 관련 코드를 추가했습니다.

## 📎 관련 이슈

closes: #18 

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

테스트 코드가 필요없는 `swagger`를 사용하지 않고 `restdocs`를 사용해보았습니다. 이번에 프로젝트를 진행하면서 테스트 코드 작성을 적극적으로 했으면 좋겠다고 생각해서 테스트 코드가 필요없는 `swagger`를 사용하지 않고 `restdocs`를 사용해보았습니다. `restdocs`와 `swagger`를 함께 사용할 수 있는 방안도 있으니 의견 주시면 감사하겠습니다.

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
