### PR TITLE
Authorization Server에서 Oauth 2.0, OIDC를 사용하여 인증 및 인가를 처리할 수 있도록 구현한다.

### DIFF
--- a/api-member/build.gradle
+++ b/api-member/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(':domain-member')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.security:spring-security-oauth2-authorization-server:0.4.0'
     testImplementation "org.testcontainers:localstack:1.17.6"
     testImplementation platform('com.amazonaws:aws-java-sdk-bom:1.12.360')
     testImplementation "com.amazonaws:aws-java-sdk-s3"

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
@@ -1,0 +1,160 @@
+package com.seeyouletter.api_member.config;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.authorization.InMemoryOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Set;
+
+import static java.security.KeyPairGenerator.getInstance;
+import static java.util.UUID.randomUUID;
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+import static org.springframework.security.config.Customizer.withDefaults;
+import static org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE;
+import static org.springframework.security.oauth2.core.ClientAuthenticationMethod.NONE;
+import static org.springframework.security.oauth2.core.oidc.OidcScopes.*;
+import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames.ID_TOKEN;
+import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.ACCESS_TOKEN;
+import static org.springframework.security.oauth2.server.authorization.client.RegisteredClient.withId;
+import static org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration.applyDefaultSecurity;
+
+@Configuration(proxyBeanMethods = false)
+public class AuthorizationServerConfiguration {
+
+    @Bean
+    @Order(value = HIGHEST_PRECEDENCE)
+    public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        applyDefaultSecurity(httpSecurity);
+
+        return httpSecurity
+                .getConfigurer(OAuth2AuthorizationServerConfigurer.class)
+                .oidc(withDefaults())
+                .and()
+                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
+                .formLogin(withDefaults())
+                .build();
+    }
+
+    @Bean
+    public RegisteredClientRepository registeredClientRepository() {
+        Set<String> allowedOidcScopes = Set.of(OPENID, PROFILE, EMAIL, ADDRESS, PHONE);
+        Set<String> allowedCustomScopes = Set.of("user.read", "user.write");
+
+        RegisteredClient registeredClient = withId(randomUUID().toString())
+                .clientId("seeyouletter")
+                .clientAuthenticationMethod(NONE)
+                .authorizationGrantType(AUTHORIZATION_CODE)
+                .redirectUri("http://127.0.0.1:8600/authorized")
+                .scopes(scopes -> {
+                    scopes.addAll(allowedOidcScopes);
+                    scopes.addAll(allowedCustomScopes);
+                })
+                .clientSettings(
+                        ClientSettings
+                                .builder()
+                                .requireProofKey(true)
+                                .requireAuthorizationConsent(false)
+                                .build()
+                )
+                .build();
+
+        return new InMemoryRegisteredClientRepository(registeredClient);
+    }
+
+    @Bean
+    public OAuth2AuthorizationService authorizationService() {
+        // TODO Implement Custom service
+        return new InMemoryOAuth2AuthorizationService();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder(JWKSource<SecurityContext> jwkSource) {
+        return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
+    }
+
+    @Bean
+    public JWKSource<SecurityContext> jwkSource() {
+        RSAKey rsaKey = generateRsa();
+        JWKSet jwkSet = new JWKSet(rsaKey);
+
+        return (jwkSelector, securityContext) -> jwkSelector.select(jwkSet);
+    }
+
+    private static RSAKey generateRsa() {
+        KeyPair keyPair = generateRsaKey();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        return new RSAKey
+                .Builder(publicKey)
+                .privateKey(privateKey)
+                .keyID(randomUUID().toString())
+                .build();
+    }
+
+    private static KeyPair generateRsaKey() {
+        try {
+            KeyPairGenerator keyPairGenerator = getInstance("RSA");
+
+            keyPairGenerator.initialize(2048);
+            return keyPairGenerator.generateKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Bean
+    public AuthorizationServerSettings authorizationServerSettings() {
+        return AuthorizationServerSettings
+                .builder()
+                .build();
+    }
+
+    @Bean
+    public OAuth2TokenCustomizer<JwtEncodingContext> oAuth2TokenCustomizer() {
+        return context -> {
+            JwtClaimsSet.Builder claims = context.getClaims();
+
+            if (context.getTokenType().equals(ACCESS_TOKEN)) {
+                String name = context
+                        .getPrincipal()
+                        .getName();
+
+                claims.claim("sub", name);
+
+                return;
+            }
+
+            if (context.getTokenType().getValue().equals(ID_TOKEN)) {
+                // TODO Customize claims for id_token
+            }
+        };
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
@@ -1,0 +1,41 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .authorizeRequests()
+                .anyRequest()
+                .authenticated()
+                .and()
+                .formLogin(withDefaults())
+                .build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User
+                .withDefaultPasswordEncoder()
+                .username("user")
+                .password("password")
+                .roles("USER")
+                .build();
+
+        return new InMemoryUserDetailsManager(user);
+    }
+
+
+}

--- a/api-member/src/main/resources/application-local.yml
+++ b/api-member/src/main/resources/application-local.yml
@@ -25,6 +25,8 @@ aws:
 logging:
   level:
     org:
+      springframework:
+        security: DEBUG
       hibernate:
         SQL: DEBUG
         type:

--- a/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
@@ -1,5 +1,6 @@
 package com.seeyouletter.api_member;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -24,6 +25,9 @@ public abstract class IntegrationTestContext {
 
     @Autowired
     protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     public static final OperationRequestPreprocessor REQUEST_PREPROCESSOR;
 

--- a/api-member/src/test/java/com/seeyouletter/api_member/e2e/Oauth2AuthorizationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/e2e/Oauth2AuthorizationTest.java
@@ -1,0 +1,288 @@
+package com.seeyouletter.api_member.e2e;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.seeyouletter.api_member.IntegrationTestContext;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.String.join;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.security.MessageDigest.getInstance;
+import static java.util.UUID.randomUUID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE;
+import static org.springframework.security.oauth2.core.ClientAuthenticationMethod.NONE;
+import static org.springframework.security.oauth2.core.oidc.OidcScopes.*;
+import static org.springframework.security.oauth2.server.authorization.client.RegisteredClient.withId;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName(value = "Oauth2 인증 및 인가 테스트")
+class Oauth2AuthorizationTest extends IntegrationTestContext {
+
+    private static final RegisteredClient publicClient;
+
+    @Autowired
+    private JwtDecoder jwtDecoder;
+
+    static {
+        publicClient = createOauth2PublicClient();
+    }
+
+    static RegisteredClient createOauth2PublicClient() {
+        Set<String> allowedOidcScopes = Set.of(OPENID, PROFILE, EMAIL, ADDRESS, PHONE);
+        Set<String> allowedCustomScopes = Set.of("user.read", "user.write");
+
+        return withId(randomUUID().toString())
+                .clientId("test-public-client")
+                .clientAuthenticationMethod(NONE)
+                .authorizationGrantType(AUTHORIZATION_CODE)
+                .redirectUri("http://127.0.0.1:8600/authorized")
+                .scopes(scopes -> {
+                    scopes.addAll(allowedOidcScopes);
+                    scopes.addAll(allowedCustomScopes);
+                })
+                .clientSettings(
+                        ClientSettings
+                                .builder()
+                                .requireProofKey(true)
+                                .requireAuthorizationConsent(false)
+                                .build()
+                )
+                .build();
+    }
+
+    @BeforeAll
+    static void setUp(@Autowired RegisteredClientRepository registeredClientRepository) {
+        registeredClientRepository.save(publicClient);
+    }
+
+    private String generateCodeVerifier() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] codeVerifier = new byte[32];
+
+        secureRandom.nextBytes(codeVerifier);
+
+        return Base64
+                .getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(codeVerifier);
+    }
+
+    private String generateCodeChallenge(String codeVerifier) {
+        try {
+            MessageDigest messageDigest = getInstance("SHA-256");
+            byte[] bytes = codeVerifier.getBytes(US_ASCII);
+            byte[] digest = messageDigest.digest(bytes);
+
+            return Base64
+                    .getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Map<String, String> parseRedirectQueryString(MvcResult mvcResult) throws URISyntaxException {
+        String redirectedUrl = mvcResult
+                .getResponse()
+                .getRedirectedUrl();
+
+        return URLEncodedUtils
+                .parse(new URI(redirectedUrl), UTF_8)
+                .stream()
+                .collect(
+                        Collectors.toMap(
+                                NameValuePair::getName,
+                                NameValuePair::getValue
+                        )
+                );
+    }
+
+    private Map<String, Object> parsePayloadFields(MvcResult mvcResult) throws IOException {
+        String payload = mvcResult
+                .getResponse()
+                .getContentAsString();
+
+        return objectMapper.readValue(payload, new TypeReference<>() {
+        });
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName(value = "authorization")
+    void authorization() throws Exception {
+        // given
+        String clientId = publicClient.getClientId();
+        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
+        String scope = join(" ", publicClient.getScopes());
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        String state = randomUUID().toString();
+        String nonce = randomUUID().toString();
+
+        // when & then
+        MvcResult authorizationResult = mockMvc
+                .perform(
+                        get("/oauth2/authorize")
+                                .with(csrf())
+                                .queryParam("client_id", clientId)
+                                .queryParam("redirect_uri", redirectUri)
+                                .queryParam("scope", scope)
+                                .queryParam("response_type", "code")
+                                .queryParam("code_challenge", codeChallenge)
+                                .queryParam("code_challenge_method", "S256")
+                                .queryParam("state", state)
+                                .queryParam("nonce", nonce)
+                )
+                .andExpect(status().is3xxRedirection())
+                .andDo(print())
+                .andDo(
+                        document(
+                                "authorization",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                requestParameters(
+                                        parameterWithName("client_id").description("클라이언트 id"),
+                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri"),
+                                        parameterWithName("scope").description("토큰의 인가 범위").optional(),
+                                        parameterWithName("response_type").description("응답 유형, code 고정으로 사용"),
+                                        parameterWithName("code_challenge").description("해시 값, Base64(SHA256(code_verifier))"),
+                                        parameterWithName("code_challenge_method").description("해시 방식, S256 고정으로 사용"),
+                                        parameterWithName("state").description("리다이렉트 callback uri로 전달되는 값").optional(),
+                                        parameterWithName("nonce").description("id_token claim에 포함되는 값").optional()
+                                ),
+                                responseHeaders(
+                                        headerWithName(LOCATION).description(LOCATION)
+                                )
+                        )
+                )
+                .andReturn();
+
+        Map<String, String> queryStrings = parseRedirectQueryString(authorizationResult);
+
+        assertThat(queryStrings.get("state"), is(equalTo(state)));
+        assertThat(queryStrings.get("code"), is(not(emptyOrNullString())));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName(value = "token")
+    void token() throws Exception {
+        // given
+        String clientId = publicClient.getClientId();
+        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
+        String scope = join(" ", publicClient.getScopes());
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        String state = randomUUID().toString();
+        String nonce = randomUUID().toString();
+
+        // when & then
+        MvcResult authorizationResult = mockMvc
+                .perform(
+                        get("/oauth2/authorize")
+                                .with(csrf())
+                                .queryParam("client_id", clientId)
+                                .queryParam("redirect_uri", redirectUri)
+                                .queryParam("scope", scope)
+                                .queryParam("response_type", "code")
+                                .queryParam("code_challenge", codeChallenge)
+                                .queryParam("code_challenge_method", "S256")
+                                .queryParam("state", state)
+                                .queryParam("nonce", nonce)
+                )
+                .andExpect(status().is3xxRedirection())
+                .andDo(print())
+                .andReturn();
+
+        Map<String, String> queryStrings = parseRedirectQueryString(authorizationResult);
+
+        assertThat(queryStrings.get("state"), is(equalTo(state)));
+        assertThat(queryStrings.get("code"), is(not(emptyOrNullString())));
+
+        MvcResult tokenResult = mockMvc
+                .perform(
+                        post("/oauth2/token")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .param("client_id", clientId)
+                                .param("code", queryStrings.get("code"))
+                                .param("code_verifier", codeVerifier)
+                                .param("grant_type", "authorization_code")
+                                .param("redirect_uri", redirectUri)
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document(
+                                "token",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                requestHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                requestParameters(
+                                        parameterWithName("client_id").description("클라이언트 id"),
+                                        parameterWithName("code").description("인가 코드"),
+                                        parameterWithName("code_verifier").description("해시 원본 값").optional(),
+                                        parameterWithName("grant_type").description("인증 방식, authorization_code 고정으로 사용"),
+                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri")
+                                ),
+                                responseHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                responseFields(
+                                        fieldWithPath("access_token").description("엑세스 토큰"),
+                                        fieldWithPath("scope").description("엑세스 토큰의 인가 범위"),
+                                        fieldWithPath("id_token").description("인증 토큰, 인가 요청시 scope로 openid를 전달한 경우에만 발급").optional(),
+                                        fieldWithPath("token_type").description("토큰 타입, Bearer 고정으로 사용"),
+                                        fieldWithPath("expires_in").description("토큰의 남은 유효기간")
+                                )
+                        )
+                )
+                .andReturn();
+
+        Map<String, Object> fields = parsePayloadFields(tokenResult);
+        Jwt idToken = jwtDecoder.decode((String) fields.get("id_token"));
+
+        assertThat(nonce, is(equalTo(idToken.getClaim("nonce"))));
+    }
+
+}

--- a/api-member/src/test/resources/application-test.yml
+++ b/api-member/src/test/resources/application-test.yml
@@ -21,6 +21,8 @@ aws:
 logging:
   level:
     org:
+      springframework:
+        security: DEBUG
       hibernate:
         SQL: DEBUG
         type:


### PR DESCRIPTION
## 💌 설명

<!-- 해당 PR에 대하여 간단한 설명이 필요해요! 🙆🏻 -->

[해당 PR은 221224 인증 flow 및 token 관리 절차에서 논의하여 도출된 결과에 따라 구현합니다.](https://github.com/seeyouletter/docs/pull/2)

spring-security-oauth2-authorization-server 프레임워크에서 지원하는 oauth2, oidc를 사용하도록 filter chain을 구성했습니다. 정상 작동을 확인하는 케이스에 대한 테스트 코드를 작성했고, 문서를 생성할 수 있는 스니펫은 생성된 상태이지만 스니펫을 사용하는 doc 파일은 작성하지 않은 상태입니다. REST API 문서의 형식에 대해서 논의 후에 생성된 스니펫으로 문서를 생성하는 이슈를 생성하고 작업을 진행할 예정입니다.

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

[seeyouletter-fe #35](https://github.com/seeyouletter/seeyouletter-fe/issues/35)

closes #12 

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

- [Oauth 2.0 - PKCE](https://oauth.net/2/pkce/)
- [Okta - PKCE Playground](https://www.oauth.com/playground/authorization-code-with-pkce.html)
- [OpenID - OpenID Connect](https://openid.net/connect/)
- [OpenID - OpenID Connect Playground](https://openidconnect.net/)
- [auth0 - Opaque access tokens](https://auth0.com/docs/secure/tokens/access-tokens#opaque-access-tokens)
- [auth0 - JWT access tokens](https://auth0.com/docs/secure/tokens/access-tokens#jwt-access-tokens)
- [spring-security-oauth2-authorization-server](https://docs.spring.io/spring-authorization-server/docs/current/reference/html/overview.html)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
