### PR TITLE
Resource Server에서 Authorization Server가 생성한 엑세스 토큰으로 인가를 처리할 수 있도록 구현한다.

### DIFF
--- a/api-letter/build.gradle
+++ b/api-letter/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(':domain-letter')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     testImplementation "org.testcontainers:localstack:1.17.6"
     testImplementation platform('com.amazonaws:aws-java-sdk-bom:1.12.360')
     testImplementation "com.amazonaws:aws-java-sdk-s3"

--- a/api-letter/src/main/java/com/seeyouletter/api_letter/config/ResourceServiceConfiguration.java
+++ b/api-letter/src/main/java/com/seeyouletter/api_letter/config/ResourceServiceConfiguration.java
@@ -1,0 +1,23 @@
+package com.seeyouletter.api_letter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class ResourceServiceConfiguration {
+
+    @Bean
+    public SecurityFilterChain resourceServerSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .requestMatchers()
+                .mvcMatchers("/api/**")
+                .and()
+                .oauth2ResourceServer()
+                .jwt();
+
+        return httpSecurity.build();
+    }
+
+}

--- a/api-letter/src/main/resources/application-local.yml
+++ b/api-letter/src/main/resources/application-local.yml
@@ -5,6 +5,11 @@ spring:
   data:
     mongodb:
       uri: mongodb://app:1234@localhost:27017/seeyouletter
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:8600
 
 aws:
   endpoint: http://127.0.0.1:4566

--- a/api-letter/src/test/resources/application-test.yml
+++ b/api-letter/src/test/resources/application-test.yml
@@ -1,3 +1,10 @@
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:8600
+
 aws:
   s3:
     region: test

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/ResourceServiceConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/ResourceServiceConfiguration.java
@@ -1,0 +1,23 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class ResourceServiceConfiguration {
+
+    @Bean
+    public SecurityFilterChain resourceServerSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .requestMatchers()
+                .mvcMatchers("/api/**")
+                .and()
+                .oauth2ResourceServer()
+                .jwt();
+
+        return httpSecurity.build();
+    }
+
+}

--- a/api-member/src/main/resources/application-local.yml
+++ b/api-member/src/main/resources/application-local.yml
@@ -16,6 +16,11 @@ spring:
         default_batch_fetch_size: 1000
         format_sql: true
     open-in-view: false
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:${server.port}
 
 aws:
   endpoint: http://127.0.0.1:4566

--- a/api-member/src/test/resources/application-test.yml
+++ b/api-member/src/test/resources/application-test.yml
@@ -13,6 +13,11 @@ spring:
         default_batch_fetch_size: 1000
         format_sql: true
       open-in-view: false
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:${server.port}
 
 aws:
   s3:


### PR DESCRIPTION
## 💌 설명

<!-- 해당 PR에 대하여 간단한 설명이 필요해요! 🙆🏻 -->

[해당 PR은 221224 인증 flow 및 token 관리 절차에서 논의하여 도출된 결과에 따라 구현합니다.](https://github.com/seeyouletter/docs/pull/2)

spring-boot-starter-oauth2-resource-server 프레임워크에서 지원하는 oauth2를 사용하여 filter chain을 구성했습니다. 엑세스 토큰이 가진 `scope`에 따라 인가를 처리하도록 애노테이션 방식의 `method security`(`@PreAuthorize`, `@Secured` 등)를 사용하는 설정을 적용했습니다.

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

closes #10 

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

filter chain에서 인가 처리에 사용할 방식에서 `web security`와 `method security` 중 어떤 방식을 사용할지 고민했습니다. `web security` 방식은 API의 endpoint가 변경되면 설정의 적용되는 URL을 함께 변경해야 하는데, 변경을 하지 않아 endpoint의 접근 제어가 적용되지 않는 경우가 발생할 수 있습니다. 또한 API 접근에 필요한 권한을 한 눈에 알아보기 어렵고 설정이 많아지는 경우에 가독성이 좋지 않아지기 때문에 `method security` 방식을 채택했습니다. 마찬가지로 spring security에서도 `method security`를 권하고 있지만 다른 의견이 있을지 논의해보면 좋을 것 같습니다.

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

- [web-security](https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html)
- [method-security](https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
