### PR TITLE
메모리에서 관리하기 적합한 데이터들을 Redis를 사용하여 저장 및 사용할 수 있도록 의존성과 설정을 추가한다.

### DIFF
--- a/api-letter/src/test/java/com/seeyouletter/api_letter/IntegrationTestContext.java
+++ b/api-letter/src/test/java/com/seeyouletter/api_letter/IntegrationTestContext.java
@@ -62,7 +62,7 @@ public abstract class IntegrationTestContext {
     }
 
     private static MongoDBContainer createMongoDBContainer() {
-        return new MongoDBContainer(createDockerImageName());
+        return new MongoDBContainer(createMongoDBDockerImageName());
     }
 
     private static LocalStackContainer createLocalStackContainer() {
@@ -86,7 +86,7 @@ public abstract class IntegrationTestContext {
                 .toString();
     }
 
-    private static DockerImageName createDockerImageName() {
+    private static DockerImageName createMongoDBDockerImageName() {
         return DockerImageName
                 .parse(MONGODB_IMAGE)
                 .withTag(MONGODB_VERSION);

--- a/api-member/build.gradle
+++ b/api-member/build.gradle
@@ -4,8 +4,11 @@ dependencies {
     implementation project(':domain-member')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.data:spring-data-redis'
     implementation 'org.springframework.security:spring-security-oauth2-authorization-server:0.4.0'
+    runtimeOnly 'io.lettuce:lettuce-core'
     testImplementation "org.testcontainers:localstack:1.17.6"
+    testImplementation 'org.testcontainers:junit-jupiter:1.17.6'
     testImplementation platform('com.amazonaws:aws-java-sdk-bom:1.12.360')
     testImplementation "com.amazonaws:aws-java-sdk-s3"
     testImplementation testFixtures(project(":domain-member"))

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/RedisConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/RedisConfiguration.java
@@ -1,0 +1,37 @@
+package com.seeyouletter.api_member.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+import static org.springframework.data.redis.serializer.RedisSerializer.string;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+@EnableConfigurationProperties(value = RedisProperties.class)
+public class RedisConfiguration {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setDefaultSerializer(string());
+
+        return redisTemplate;
+    }
+
+}

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -33,5 +33,12 @@ services:
     volumes:
       - ~/docker/mongo/data:/data/db
       - ./mongo/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+  redis:
+    image: redis:7.0.5
+    container_name: redis
+    ports:
+      - 6379:6379
+    volumes:
+      - ~/docker/redis/data:/data
 
 


### PR DESCRIPTION
## 💌 설명

<!-- 해당 PR에 대하여 간단한 설명이 필요해요! 🙆🏻 -->

여러 개의 애플리케이션에서 관계형 데이터베이스보다는 인메모리에서 관리하기 적합한 데이터들을 저장 및 사용하기 위해 애플리케이션에서 `redis`를 사용할 수 있도록 의존성과 설정을 추가합니다. 캐시, 클러스터링 또는 특정 자료구조를 활용하면 효율적으로 데이터를 처리할 수 있는 경우에 효율적으로 사용할 수 있다고 생각하여 해당 작업을 진행했습니다.     
애플리케이션에서 `redis`를 high level abstraction으로 사용할 수 있도록 제공되는 `RedisTemplate`, `repository interface`를 사용하기 위한 설정을 추가했습니다. 로컬 및 테스트 환경에서도 분리된 인프라를 사용하기 위해 로컬 프로파일에서는 `docker-compose` 파일에 `redis` 관련 설정을 추가하였고, 테스트 프로파일에서는`test-container`를 사용하는 테스트 공통 클래스에 `redis` 컨테이너 설정을 추가했습니다.

## 📎 관련 이슈

#16 #15 #14 세션 클러스터링과 프레임워크에서 사용되는 인메모리 저장소의 커스텀한 구현에 `redis`를 활용할 수 있을 것 같습니다.

#22 프레임워크에서 사용되는 인메모리 저장소의 커스텀한 구현에 `redis`를 활용할 수 있을 것 같습니다.

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항
`redis`를 사용해본 적은 있지만 경험이 많지 않아서 client로 `jedis`, `lettuce`, `redisson` 중 어느 것을 사용하면 좋을지 결정할 수 없었습니다. 여러 개의 비교 글을 읽어본 결과 몇 가지 차이를 요약하면 `lettuce`는 비동기식 이벤트 기반의 `netty`를 사용하기 때문에 좋은 성능을 낼 수 있습니다. `redisson`도 마찬가지로 `netty`를 사용하며 락의 타임 아웃을 지정할 수 있고 락의 획득 가능 여부를 스핀락이 아닌 pub/sub으로 확인하여 부하를 많이 줄일 수 있습니다. `jedis`는 API가 단순하여 사용하기가 굉장히 쉽습니다. 
`spring-data-redis`에서 지원하는 `RedisTemplate` 또는 `repositorty interface`를 통해 `redis`를 사용하기 때문에 사용하기 쉽다는 `jedis`의 장점이 부각될 것 이라고 생각되지 않았습니다. `redisson`은 직접 스프링과 통합할 수 있는 프레임워크를 지원하고 있지만 `lettuce`는 `spring-data-redis`에서 `jedis`, `lettuce`를 통합하여 사용할 수 있도록 공식적으로 지원하기 떄문에 스프링 생태계에서 지원하는 프레임워크를 사용할 수 있습니다. 현재 상황에서 당장 분산 락을 구현할 필요가 없으므로 `lettuce`를 사용하는 것이 적합하다고 생각했습니다. 세 가지 클라이언트가 모두 특징을 가지고 있지만 `redis`와 각 클라이언트를 사용해본 경험이 없기 때문에 우선 `letttuce`를 사용해보고 다른 클라이언트로 교체해도 좋을 것 같습니다. 좋은 의견이 있으시면 공유해주세요 😄

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

- [jojoldu - Jedis보다 Lettuce를 쓰자](https://jojoldu.tistory.com/418)
- [redis - Jedis vs. Lettuce: An Exploration](https://redis.com/blog/jedis-vs-lettuce-an-exploration/)
- [hyperconnect - 레디스를 활용한 분산 락과 안전하고 빠른 락의 구현](https://hyperconnect.github.io/2019/11/15/redis-distributed-lock-1.html)
- [spring docs - spring-data-redis](https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/#redis:requirements)
- [reddison - reddison-spring-data](https://github.com/redisson/redisson/tree/master/redisson-spring-data)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
