### PR TITLE
testcontainers가 class가 아닌 application context 범위로 라이프사이클이 적용되도록 변경한다.

### DIFF
--- a/api-letter/src/test/java/com/seeyouletter/api_letter/IntegrationTestContext.java
+++ b/api-letter/src/test/java/com/seeyouletter/api_letter/IntegrationTestContext.java
@@ -13,14 +13,11 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.nio.file.Paths;
 
 import static org.springframework.http.HttpHeaders.*;
-import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.testcontainers.containers.BindMode.READ_ONLY;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
@@ -29,14 +26,11 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @SpringBootTest
-@Testcontainers
 @ActiveProfiles(profiles = "test")
 public abstract class IntegrationTestContext {
 
-    @Container
     private static final MongoDBContainer MONGODB_CONTAINER;
 
-    @Container
     public static final LocalStackContainer LOCAL_STACK_CONTAINER;
 
     private static final String MONGODB_VERSION = "5.0.14";
@@ -59,6 +53,8 @@ public abstract class IntegrationTestContext {
         LOCAL_STACK_CONTAINER = createLocalStackContainer();
         REQUEST_PREPROCESSOR = createRequestPreprocessor();
         RESPONSE_PREPROCESSOR = createResponsePreprocessor();
+        MONGODB_CONTAINER.start();
+        LOCAL_STACK_CONTAINER.start();
     }
 
     private static MongoDBContainer createMongoDBContainer() {

--- a/api-member/build.gradle
+++ b/api-member/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-authorization-server:0.4.0'
     runtimeOnly 'io.lettuce:lettuce-core'
     testImplementation "org.testcontainers:localstack:1.17.6"
-    testImplementation 'org.testcontainers:junit-jupiter:1.17.6'
     testImplementation platform('com.amazonaws:aws-java-sdk-bom:1.12.360')
     testImplementation "com.amazonaws:aws-java-sdk-s3"
     testImplementation testFixtures(project(":domain-member"))

--- a/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
@@ -14,8 +14,6 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.springframework.http.HttpHeaders.*;
@@ -26,11 +24,9 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @SpringBootTest
-@Testcontainers
 @ActiveProfiles(value = "test")
 public abstract class IntegrationTestContext {
 
-    @Container
     private static final GenericContainer<?> REDIS_CONTAINER;
 
     private static final String REDIS_VERSION = "7.0.5";
@@ -51,6 +47,7 @@ public abstract class IntegrationTestContext {
         REDIS_CONTAINER = createRedisContainer();
         REQUEST_PREPROCESSOR = createRequestPreprocessor();
         RESPONSE_PREPROCESSOR = createResponsePreprocessor();
+        REDIS_CONTAINER.start();
     }
 
     private static GenericContainer<?> createRedisContainer() {

--- a/domain-letter/build.gradle
+++ b/domain-letter/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     testFixturesApi 'org.testcontainers:mongodb:1.17.6'
-    testFixturesApi 'org.testcontainers:junit-jupiter:1.17.6'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage:junit-vintage-engine'
     }

--- a/domain-letter/src/test/java/com/seeyouletter/domain_letter/MongoTestContext.java
+++ b/domain-letter/src/test/java/com/seeyouletter/domain_letter/MongoTestContext.java
@@ -2,20 +2,15 @@ package com.seeyouletter.domain_letter;
 
 import org.junit.jupiter.api.Disabled;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @Disabled
 @DataMongoTest
-@Testcontainers
 public abstract class MongoTestContext {
 
-    @Container
     private static final MongoDBContainer MONGODB_CONTAINER;
 
     private static final String MONGODB_VERSION = "5.0.14";
@@ -24,6 +19,7 @@ public abstract class MongoTestContext {
 
     static {
         MONGODB_CONTAINER = createMongoDBContainer();
+        MONGODB_CONTAINER.start();
     }
 
     private static MongoDBContainer createMongoDBContainer() {


### PR DESCRIPTION
## 💌 설명

컨테이너에 의존하는 테스트에서 동일한 application context는 실행한 컨테이너를 재사용하기 위해 `@TestContainers`, `@Container` 애노테이션들을 적용하였습니다. 하지만 해당 애노테이션들은 컨테이너를 하나의 클래스 단위의 라이프사이클을 가지도록하여 다른 테스트 클래스에서는 새로운 컨테이너를 실행하며 공유되지 않습니다. 
현재 동일한 application context를 공유할 수 있는 경우에 캐시하고 재사용할 수 있도록 상위 클래스를 상속받아 사용하고 있고 컨테이너가 상위 클래스에 정의되어있습니다. 동일한 클래스를 상속받아 각 테스트 클래스는 동일한 application context를 사용하게되지만, 컨테이너는 동일한 application context를 사용함에도 불구하고 다른 테스트 클래스에 존재하는 테스트 메소드를 수행하는 시점에 컨테이너를 다시 실행하게 되어 application context에서 접근 하려고하는 컨테이너와 대상이 다르게 되어 접근할 수 없게됩니다. 
따라서 다른 테스트 클래스에서 컨테이너 접근시 에러가 발생하여 class가 아닌 application context 범위로 라이프사이클을 가질 수 있도록 애노테이션을 제거했습니다.

## 📎 관련 이슈

## 💡 논의해볼 사항

## 📝 참고자료

- [Jupiter / Junit5](https://www.testcontainers.org/test_framework_integration/junit_5/)
- [Manual container lifecycle control](https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers)

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
