### PR TITLE
fix(workflow): gradle wrapper를 cache하도록 변경하고 불필요하게 전체 모듈을 build하지 않도록…

### DIFF
--- a/.github/workflows/api-letter-pull-request.yml
+++ b/.github/workflows/api-letter-pull-request.yml
@@ -31,11 +31,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+      - name: Gradle Caching
+        uses: actions/cache@v3
         with:
-          arguments: build
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Build
-        run:  ./gradlew :api-letter:build
+        run:  ./gradlew :api-letter:clean :api-letter:build

--- a/.github/workflows/api-member-pull-request.yml
+++ b/.github/workflows/api-member-pull-request.yml
@@ -31,11 +31,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+      - name: Gradle Caching
+        uses: actions/cache@v3
         with:
-          arguments: build
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Build
-        run:  ./gradlew :api-member:build
+        run:  ./gradlew :api-member:clean :api-member:build

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -32,13 +32,17 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+      - name: Gradle Caching
+        uses: actions/cache@v3
         with:
-          arguments: build
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Build & Upload coverage to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew jacocoRootReport coveralls
+        run: ./gradlew clean jacocoRootReport coveralls


### PR DESCRIPTION
## 💌 설명

<img width="1320" alt="스크린샷 2023-01-23 오후 3 22 06" src="https://user-images.githubusercontent.com/75176643/213977217-24f788cf-7edd-45b2-9617-e77599917378.png">

gradle wrapper를 cache하도록 변경하고 불필요하게 전체 모듈을 build하지 않도록 기존 gradle cache step 제거

- 기존 step(gradle/gradle-build-action@v2) 제거
- gradle wrapper를 사용하고 캐시하는 step(actions/cache@v3) 추가

## 📎 관련 이슈

## 💡 논의해볼 사항

## 📝 참고자료

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
