### PR TITLE
Spring Authorization Server의 OAuth2AuthorizationService 구현체인 RedisOauth2Authorization Service를 구현한다.

### DIFF
--- a/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
@@ -7,14 +7,12 @@ import com.nimbusds.jose.proc.SecurityContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
-import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.server.authorization.InMemoryOAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
-import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
@@ -66,7 +64,7 @@ public class AuthorizationServerConfiguration {
         Set<String> allowedOidcScopes = Set.of(OPENID, PROFILE, EMAIL, ADDRESS, PHONE);
         Set<String> allowedCustomScopes = Set.of("user.read", "user.write");
 
-        RegisteredClient registeredClient = withId(randomUUID().toString())
+        RegisteredClient registeredClient = withId("98348f89-5433-41a1-b12d-657f4f3d19f9")
                 .clientId("seeyouletter")
                 .clientAuthenticationMethod(NONE)
                 .authorizationGrantType(AUTHORIZATION_CODE)
@@ -88,9 +86,9 @@ public class AuthorizationServerConfiguration {
     }
 
     @Bean
-    public OAuth2AuthorizationService authorizationService() {
-        // TODO Implement Custom service
-        return new InMemoryOAuth2AuthorizationService();
+    public OAuth2AuthorizationService authorizationService(StringRedisTemplate stringRedisTemplate,
+                                                           RegisteredClientRepository registeredClientRepository) {
+        return new RedisOauth2AuthorizationService(stringRedisTemplate, registeredClientRepository);
     }
 
     @Bean

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/RedisConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/RedisConfiguration.java
@@ -7,10 +7,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-
-import static org.springframework.data.redis.serializer.RedisSerializer.string;
 
 @Configuration
 @EnableRedisRepositories
@@ -26,12 +24,8 @@ public class RedisConfiguration {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setDefaultSerializer(string());
-
-        return redisTemplate;
+    public StringRedisTemplate stringRedisTemplate() {
+        return new StringRedisTemplate(redisConnectionFactory());
     }
 
 }

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/RedisOauth2AuthorizationService.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/RedisOauth2AuthorizationService.java
@@ -1,0 +1,598 @@
+package com.seeyouletter.api_member.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.connection.RedisStringCommands;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization.Token;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationCode;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module;
+import org.springframework.util.Assert;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.security.MessageDigest.getInstance;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+import static org.springframework.data.redis.connection.RedisStringCommands.SetOption.UPSERT;
+import static org.springframework.data.redis.core.types.Expiration.from;
+import static org.springframework.security.jackson2.SecurityJackson2Modules.getModules;
+import static org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE;
+import static org.springframework.security.oauth2.core.AuthorizationGrantType.CLIENT_CREDENTIALS;
+import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType.BEARER;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.CODE;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.STATE;
+import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.ACCESS_TOKEN;
+import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.REFRESH_TOKEN;
+
+public final class RedisOauth2AuthorizationService implements OAuth2AuthorizationService {
+
+    private static final Duration AUTHORIZATION_CONSENT_TIME_LIMIT = Duration.of(5, MINUTES);
+
+    private static final Duration AUTHORIZATION_TOKEN_REQUEST_TIME_LIMIT = Duration.of(5, MINUTES);
+
+    private static final Duration REDIS_TIME_TO_LIVE_ADD_TIME = Duration.of(3, MINUTES);
+
+    public static final String AUTHORIZATION_KEY_PREFIX = "authorization:";
+
+    public static final String AUTHORIZATION_CONSENT_STATE_KEY_PREFIX = "authorization:consent:state:";
+
+    public static final String AUTHORIZATION_CODE_KEY_PREFIX = "authorization:code:";
+
+    public static final String AUTHORIZATION_ACCESS_TOKEN_KEY_PREFIX = "authorization:access_token:";
+
+    public static final String AUTHORIZATION_REFRESH_TOKEN_KEY_PREFIX = "authorization:refresh_token:";
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModules(getModules(this.getClass().getClassLoader()))
+            .registerModule(new OAuth2AuthorizationServerJackson2Module())
+            .addMixIn(Authorization.class, AuthorizationMixIn.class);
+
+    private final RegisteredClientRepository registeredClientRepository;
+
+    private final ValueOperations<String, String> valueOperations;
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public RedisOauth2AuthorizationService(StringRedisTemplate stringRedisTemplate,
+                                           RegisteredClientRepository registeredClientRepository) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.valueOperations = stringRedisTemplate.opsForValue();
+        this.registeredClientRepository = registeredClientRepository;
+    }
+
+    @Override
+    public void save(OAuth2Authorization authorization) {
+        Assert.notNull(authorization, "authorization cannot be null");
+
+        if (isAfterAccessTokenIssued(authorization)) {
+            saveAuthorizationTokens(authorization);
+
+            return;
+        }
+
+        if (isConsent(authorization)) {
+            saveAuthorizationConsentState(authorization);
+
+            return;
+        }
+
+        saveAuthorizationCode(authorization);
+    }
+
+    @Override
+    public void remove(OAuth2Authorization authorization) {
+        Assert.notNull(authorization, "authorization cannot be null");
+
+        stringRedisTemplate.delete(AUTHORIZATION_KEY_PREFIX + authorization.getId());
+    }
+
+    @Override
+    public OAuth2Authorization findById(String id) {
+        Assert.hasText(id, "id cannot be empty");
+
+        return deserialize(valueOperations.get(AUTHORIZATION_KEY_PREFIX + id));
+    }
+
+    @Override
+    public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {
+        Assert.hasText(token, "token cannot be empty");
+
+        String authorizationId = findAuthorizationIdByTokenAndTokenType(token, tokenType);
+
+        if (authorizationId == null) {
+            return null;
+        }
+
+        return deserialize(valueOperations.get(AUTHORIZATION_KEY_PREFIX + authorizationId));
+    }
+
+    private String findAuthorizationIdByTokenAndTokenType(String token, OAuth2TokenType tokenType) {
+        if (tokenType == null) {
+            // token introspect, token revocation request
+            return valueOperations.get(AUTHORIZATION_ACCESS_TOKEN_KEY_PREFIX + encrypt(token));
+        }
+
+        if (STATE.equals(tokenType.getValue())) {
+            // authorization request(after consent)
+            return valueOperations.get(AUTHORIZATION_CONSENT_STATE_KEY_PREFIX + token);
+        }
+
+        if (CODE.equals(tokenType.getValue())) {
+            // token request, token introspect, token revocation request
+            return valueOperations.get(AUTHORIZATION_CODE_KEY_PREFIX + token);
+        }
+
+        if (ACCESS_TOKEN.equals(tokenType)) {
+            // oidc userinfo request, oidc client registration request
+            return valueOperations.get(AUTHORIZATION_ACCESS_TOKEN_KEY_PREFIX + encrypt(token));
+        }
+
+        if (REFRESH_TOKEN.equals(tokenType)) {
+            // token refresh request
+            return valueOperations.get(AUTHORIZATION_REFRESH_TOKEN_KEY_PREFIX + encrypt(token));
+        }
+
+        return null;
+    }
+
+    private void saveAuthorizationTokens(OAuth2Authorization authorization) {
+        stringRedisTemplate.executePipelined((RedisCallback<?>) connection -> {
+            RedisStringCommands redisStringCommands = connection.stringCommands();
+
+            RegisteredClient registeredClient = findClientByRegisteredClientId(authorization.getRegisteredClientId());
+
+            Token<OAuth2AuthorizationCode> authorizationCode = authorization.getToken(OAuth2AuthorizationCode.class);
+
+            if (authorizationCode != null) {
+                String authorizationCodeValue = authorizationCode
+                        .getToken()
+                        .getTokenValue();
+
+                redisStringCommands.set(
+                        toBytes(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue),
+                        toBytes(authorization.getId()),
+                        from(getClientAccessTokenTimeToLive(registeredClient)),
+                        UPSERT
+                );
+            }
+
+            Token<OAuth2AccessToken> accessToken = authorization.getAccessToken();
+
+            String accessTokenValue = accessToken
+                    .getToken()
+                    .getTokenValue();
+
+            redisStringCommands.set(
+                    toBytes(AUTHORIZATION_ACCESS_TOKEN_KEY_PREFIX + encrypt(accessTokenValue)),
+                    toBytes(authorization.getId()),
+                    from(getClientAccessTokenTimeToLive(registeredClient)),
+                    UPSERT
+            );
+
+            Token<OAuth2RefreshToken> refreshToken = authorization.getRefreshToken();
+
+            if (refreshToken != null) {
+                String refreshTokenValue = refreshToken
+                        .getToken()
+                        .getTokenValue();
+
+                redisStringCommands.set(
+                        toBytes(AUTHORIZATION_REFRESH_TOKEN_KEY_PREFIX + encrypt(refreshTokenValue)),
+                        toBytes(authorization.getId()),
+                        from(getClientRefreshTokenTimeToLive(registeredClient)),
+                        UPSERT
+                );
+            }
+
+            redisStringCommands.set(
+                    toBytes(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
+                    toBytes(serialize(authorization)),
+                    from(getClientAuthorizationTimeToLive(registeredClient)),
+                    UPSERT
+            );
+
+            return null;
+        });
+    }
+
+    private void saveAuthorizationCode(OAuth2Authorization authorization) {
+        stringRedisTemplate.executePipelined((RedisCallback<?>) connection -> {
+            RedisStringCommands redisStringCommands = connection.stringCommands();
+
+            Token<OAuth2AuthorizationCode> authorizationCode = authorization.getToken(OAuth2AuthorizationCode.class);
+
+            if (authorizationCode != null) {
+                String authorizationCodeValue = authorizationCode
+                        .getToken()
+                        .getTokenValue();
+
+                redisStringCommands.set(
+                        toBytes(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue),
+                        toBytes(authorization.getId()),
+                        from(AUTHORIZATION_TOKEN_REQUEST_TIME_LIMIT),
+                        UPSERT
+                );
+            }
+
+
+            redisStringCommands.set(
+                    toBytes(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
+                    toBytes(serialize(authorization)),
+                    from(AUTHORIZATION_TOKEN_REQUEST_TIME_LIMIT),
+                    UPSERT
+            );
+
+            return null;
+        });
+    }
+
+    private void saveAuthorizationConsentState(OAuth2Authorization authorization) {
+        stringRedisTemplate.executePipelined((RedisCallback<?>) connection -> {
+            RedisStringCommands redisStringCommands = connection.stringCommands();
+
+            redisStringCommands.set(
+                    toBytes(AUTHORIZATION_CONSENT_STATE_KEY_PREFIX + authorization.getAttribute(STATE)),
+                    toBytes(authorization.getId()),
+                    from(AUTHORIZATION_CONSENT_TIME_LIMIT),
+                    UPSERT
+            );
+
+            redisStringCommands.set(
+                    toBytes(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
+                    toBytes(serialize(authorization)),
+                    from(AUTHORIZATION_CONSENT_TIME_LIMIT),
+                    UPSERT
+            );
+
+            return null;
+        });
+    }
+
+    private boolean isConsent(OAuth2Authorization authorization) {
+        return authorization.getAttribute(STATE) != null;
+    }
+
+    private boolean isAfterAccessTokenIssued(OAuth2Authorization authorization) {
+        return authorization.getAccessToken() != null;
+    }
+
+    private RegisteredClient findClientByRegisteredClientId(String registeredClientId) {
+        RegisteredClient registeredClient = registeredClientRepository.findById(registeredClientId);
+
+        if (registeredClient == null) {
+            throw new DataRetrievalFailureException(
+                    format(
+                            "The RegisteredClient with id '%s' was not found in the RegisteredClientRepository.",
+                            registeredClientId
+                    )
+            );
+        }
+
+        return registeredClient;
+    }
+
+    private boolean hasRefreshTokenGrant(RegisteredClient registeredClient) {
+        return registeredClient
+                .getAuthorizationGrantTypes()
+                .contains(AuthorizationGrantType.REFRESH_TOKEN);
+    }
+
+    private boolean isPublicClient(RegisteredClient registeredClient) {
+        return registeredClient.getClientSecret() == null;
+    }
+
+    private Duration getClientRefreshTokenTimeToLive(RegisteredClient registeredClient) {
+        return registeredClient
+                .getTokenSettings()
+                .getRefreshTokenTimeToLive()
+                .plus(REDIS_TIME_TO_LIVE_ADD_TIME);
+    }
+
+    private Duration getClientAccessTokenTimeToLive(RegisteredClient registeredClient) {
+        return registeredClient
+                .getTokenSettings()
+                .getAccessTokenTimeToLive()
+                .plus(REDIS_TIME_TO_LIVE_ADD_TIME);
+    }
+
+    private Duration getClientAuthorizationTimeToLive(RegisteredClient registeredClient) {
+        if (isPublicClient(registeredClient) || !hasRefreshTokenGrant(registeredClient)) {
+            return getClientAccessTokenTimeToLive(registeredClient);
+        }
+
+        return getClientRefreshTokenTimeToLive(registeredClient);
+    }
+
+    private OAuth2Authorization toObject(Authorization entity) {
+        OAuth2Authorization.Builder builder = OAuth2Authorization
+                .withRegisteredClient(findClientByRegisteredClientId(entity.getRegisteredClientId()))
+                .id(entity.getId())
+                .principalName(entity.getPrincipalName())
+                .authorizationGrantType(resolveAuthorizationGrantType(entity.getAuthorizationGrantType()))
+                .authorizedScopes(entity.getAuthorizedScopes())
+                .attributes(attributes -> attributes.putAll(entity.getAttributes()));
+
+        if (entity.getState() != null) {
+            builder.attribute(STATE, entity.getState());
+        }
+
+        if (entity.getAuthorizationCodeValue() != null) {
+            OAuth2AuthorizationCode authorizationCode = new OAuth2AuthorizationCode(
+                    entity.getAuthorizationCodeValue(),
+                    entity.getAuthorizationCodeIssuedAt(),
+                    entity.getAuthorizationCodeExpiresAt()
+            );
+
+            builder.token(authorizationCode, metadata -> metadata.putAll(entity.getAuthorizationCodeMetadata()));
+        }
+
+        if (entity.getAccessTokenValue() != null) {
+            OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                    BEARER,
+                    entity.getAccessTokenValue(),
+                    entity.getAccessTokenIssuedAt(),
+                    entity.getAccessTokenExpiresAt(),
+                    entity.getAccessTokenScopes()
+            );
+
+            builder.token(accessToken, metadata -> metadata.putAll(entity.getAccessTokenMetadata()));
+        }
+
+        if (entity.getRefreshTokenValue() != null) {
+            OAuth2RefreshToken refreshToken = new OAuth2RefreshToken(
+                    entity.getRefreshTokenValue(),
+                    entity.getRefreshTokenIssuedAt(),
+                    entity.getRefreshTokenExpiresAt()
+            );
+
+            builder.token(refreshToken, metadata -> metadata.putAll(entity.getRefreshTokenMetadata()));
+        }
+
+        if (entity.getOidcIdTokenValue() != null) {
+            OidcIdToken idToken = new OidcIdToken(
+                    entity.getOidcIdTokenValue(),
+                    entity.getOidcIdTokenIssuedAt(),
+                    entity.getOidcIdTokenExpiresAt(),
+                    entity.getOidcIdTokenClaims()
+            );
+
+            builder.token(idToken, metadata -> metadata.putAll(entity.getOidcIdTokenMetadata()));
+        }
+
+        return builder.build();
+    }
+
+    private Authorization toEntity(OAuth2Authorization authorization) {
+        Authorization.AuthorizationBuilder builder = Authorization
+                .builder()
+                .id(authorization.getId())
+                .registeredClientId(authorization.getRegisteredClientId())
+                .principalName(authorization.getPrincipalName())
+                .authorizationGrantType(authorization.getAuthorizationGrantType().getValue())
+                .authorizedScopes(authorization.getAuthorizedScopes())
+                .attributes(authorization.getAttributes())
+                .state(authorization.getAttribute(STATE));
+
+        Token<OAuth2AuthorizationCode> authorizationCode = authorization.getToken(OAuth2AuthorizationCode.class);
+
+        if (authorizationCode != null) {
+            OAuth2AuthorizationCode token = authorizationCode.getToken();
+
+            builder
+                    .authorizationCodeValue(token.getTokenValue())
+                    .authorizationCodeIssuedAt(token.getIssuedAt())
+                    .authorizationCodeExpiresAt(token.getExpiresAt())
+                    .authorizationCodeMetadata(authorizationCode.getMetadata());
+        }
+
+        Token<OAuth2AccessToken> accessToken = authorization.getAccessToken();
+
+        if (accessToken != null) {
+            OAuth2AccessToken token = accessToken.getToken();
+
+            builder
+                    .accessTokenValue(token.getTokenValue())
+                    .accessTokenIssuedAt(token.getIssuedAt())
+                    .accessTokenExpiresAt(token.getExpiresAt())
+                    .accessTokenMetadata(accessToken.getMetadata())
+                    .accessTokenScopes(token.getScopes());
+        }
+
+        Token<OAuth2RefreshToken> refreshToken = authorization.getRefreshToken();
+
+        if (refreshToken != null) {
+            OAuth2RefreshToken token = refreshToken.getToken();
+
+            builder
+                    .refreshTokenValue(token.getTokenValue())
+                    .refreshTokenIssuedAt(token.getIssuedAt())
+                    .refreshTokenExpiresAt(token.getExpiresAt())
+                    .refreshTokenMetadata(refreshToken.getMetadata());
+        }
+
+        Token<OidcIdToken> oidcIdToken = authorization.getToken(OidcIdToken.class);
+
+        if (oidcIdToken != null) {
+            OidcIdToken token = oidcIdToken.getToken();
+
+            builder
+                    .oidcIdTokenValue(token.getTokenValue())
+                    .oidcIdTokenIssuedAt(token.getIssuedAt())
+                    .oidcIdTokenExpiresAt(token.getExpiresAt())
+                    .oidcIdTokenMetadata(oidcIdToken.getMetadata())
+                    .oidcIdTokenClaims(token.getClaims());
+        }
+
+        return builder.build();
+    }
+
+    private AuthorizationGrantType resolveAuthorizationGrantType(String authorizationGrantType) {
+        if (AUTHORIZATION_CODE.getValue().equals(authorizationGrantType)) {
+            return AUTHORIZATION_CODE;
+        }
+
+        if (CLIENT_CREDENTIALS.getValue().equals(authorizationGrantType)) {
+            return CLIENT_CREDENTIALS;
+        }
+
+        if (AuthorizationGrantType.REFRESH_TOKEN.getValue().equals(authorizationGrantType)) {
+            return AuthorizationGrantType.REFRESH_TOKEN;
+        }
+
+        return new AuthorizationGrantType(authorizationGrantType);
+    }
+
+    private String serialize(OAuth2Authorization authorization) {
+        try {
+            return objectMapper.writeValueAsString(toEntity(authorization));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    private OAuth2Authorization deserialize(String json) {
+        if (json == null) {
+            return null;
+        }
+
+        try {
+            return toObject(objectMapper.readValue(json, Authorization.class));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    private byte[] toBytes(String content) {
+        return content.getBytes(UTF_8);
+    }
+
+    public String encrypt(String token) {
+        MessageDigest messageDigest;
+
+        try {
+            messageDigest = getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+
+        byte[] digest = messageDigest.digest(token.getBytes(UTF_8));
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (byte b : digest) {
+            stringBuilder.append(format("%02x", b));
+        }
+
+        return stringBuilder.toString();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
+    public static class Authorization {
+
+        @Id
+        private String id;
+
+        private String registeredClientId;
+
+        private String principalName;
+
+        private String authorizationGrantType;
+
+        private Set<String> authorizedScopes;
+
+        private Map<String, Object> attributes;
+
+        private String state;
+
+        private String authorizationCodeValue;
+
+        private Instant authorizationCodeIssuedAt;
+
+        private Instant authorizationCodeExpiresAt;
+
+        private Map<String, Object> authorizationCodeMetadata;
+
+        private String accessTokenValue;
+
+        private Instant accessTokenIssuedAt;
+
+        private Instant accessTokenExpiresAt;
+
+        private Map<String, Object> accessTokenMetadata;
+
+        private String accessTokenType;
+
+        private Set<String> accessTokenScopes;
+
+        private String refreshTokenValue;
+
+        private Instant refreshTokenIssuedAt;
+
+        private Instant refreshTokenExpiresAt;
+
+        private Map<String, Object> refreshTokenMetadata;
+
+        private String oidcIdTokenValue;
+
+        private Instant oidcIdTokenIssuedAt;
+
+        private Instant oidcIdTokenExpiresAt;
+
+        private Map<String, Object> oidcIdTokenMetadata;
+
+        private Map<String, Object> oidcIdTokenClaims;
+
+    }
+
+    @JsonTypeInfo(use = CLASS)
+    @JsonAutoDetect(
+            fieldVisibility = ANY,
+            getterVisibility = NONE,
+            isGetterVisibility = NONE
+    )
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static abstract class AuthorizationMixIn {
+
+        @JsonCreator
+        AuthorizationMixIn() {
+        }
+
+    }
+
+}

--- a/api-member/src/main/resources/application-local.yml
+++ b/api-member/src/main/resources/application-local.yml
@@ -79,6 +79,7 @@ logging:
     org:
       springframework:
         security: DEBUG
+        security.jackson2: INFO
       hibernate:
         SQL: DEBUG
         type:

--- a/api-member/src/test/java/com/seeyouletter/api_member/e2e/Oauth2AuthorizationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/e2e/Oauth2AuthorizationTest.java
@@ -5,10 +5,11 @@ import com.seeyouletter.api_member.IntegrationTestContext;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
@@ -16,6 +17,7 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.io.IOException;
 import java.net.URI;
@@ -35,8 +37,8 @@ import static java.security.MessageDigest.getInstance;
 import static java.util.UUID.randomUUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -56,13 +58,309 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName(value = "Oauth2 인증 및 인가 테스트")
 class Oauth2AuthorizationTest extends IntegrationTestContext {
 
-    private static final RegisteredClient publicClient;
+    private static RegisteredClient publicClient;
 
     @Autowired
     private JwtDecoder jwtDecoder;
 
-    static {
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @BeforeAll
+    static void setUp(@Autowired RegisteredClientRepository registeredClientRepository) {
         publicClient = createOauth2PublicClient();
+        registeredClientRepository.save(publicClient);
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        stringRedisTemplate
+                .getConnectionFactory()
+                .getConnection()
+                .flushAll();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName(value = "authorization")
+    void authorization() throws Exception {
+        // given
+        String clientId = publicClient.getClientId();
+        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
+        String scope = join(" ", publicClient.getScopes());
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        String state = randomUUID().toString();
+        String nonce = randomUUID().toString();
+
+        // when & then
+        MvcResult authorizationResult = performAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, state, nonce)
+                .andDo(
+                        document(
+                                "authorization",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                requestParameters(
+                                        parameterWithName("client_id").description("클라이언트 id"),
+                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri"),
+                                        parameterWithName("scope").description("토큰의 인가 범위").optional(),
+                                        parameterWithName("response_type").description("응답 유형, code 고정으로 사용"),
+                                        parameterWithName("code_challenge").description("해시 값, Base64(SHA256(code_verifier))"),
+                                        parameterWithName("code_challenge_method").description("해시 방식, S256 고정으로 사용"),
+                                        parameterWithName("state").description("리다이렉트 callback uri로 전달되는 값").optional(),
+                                        parameterWithName("nonce").description("id_token claim에 포함되는 값").optional()
+                                ),
+                                responseHeaders(
+                                        headerWithName(LOCATION).description(LOCATION)
+                                )
+                        )
+                )
+                .andReturn();
+
+        Map<String, String> queryStrings = parseRedirectQueryString(authorizationResult);
+
+        assertThat(queryStrings.get("state"), is(equalTo(state)));
+        assertThat(queryStrings.get("code"), is(not(emptyOrNullString())));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName(value = "token")
+    void token() throws Exception {
+        // given
+        String clientId = publicClient.getClientId();
+        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
+        String scope = join(" ", publicClient.getScopes());
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        String state = randomUUID().toString();
+        String nonce = randomUUID().toString();
+
+        MvcResult authorizationResult = performAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, state, nonce)
+                .andReturn();
+
+        String code = parseRedirectQueryString(authorizationResult)
+                .get("code");
+
+        // when & then
+        MvcResult tokenResult = performTokenRequest(clientId, redirectUri, codeVerifier, code)
+                .andDo(
+                        document(
+                                "token",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                requestHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                requestParameters(
+                                        parameterWithName("client_id").description("클라이언트 id"),
+                                        parameterWithName("code").description("인가 코드"),
+                                        parameterWithName("code_verifier").description("해시 원본 값").optional(),
+                                        parameterWithName("grant_type").description("인증 방식, authorization_code 고정으로 사용"),
+                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri")
+                                ),
+                                responseHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                responseFields(
+                                        fieldWithPath("access_token").description("엑세스 토큰"),
+                                        fieldWithPath("scope").description("엑세스 토큰의 인가 범위"),
+                                        fieldWithPath("id_token").description("인증 토큰, 인가 요청시 scope로 openid를 전달한 경우에만 발급").optional(),
+                                        fieldWithPath("token_type").description("토큰 타입, Bearer 고정으로 사용"),
+                                        fieldWithPath("expires_in").description("토큰의 남은 유효기간")
+                                )
+                        )
+                )
+                .andReturn();
+
+        Map<String, Object> fields = parsePayloadFields(tokenResult);
+        Jwt idToken = jwtDecoder.decode((String) fields.get("id_token"));
+
+        assertThat(nonce, is(equalTo(idToken.getClaim("nonce"))));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName(value = "introspect")
+    void introspect() throws Exception {
+        // given
+        String clientId = publicClient.getClientId();
+        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
+        String scope = join(" ", publicClient.getScopes());
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        String state = randomUUID().toString();
+        String nonce = randomUUID().toString();
+
+        MvcResult authorizationResult = performAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, state, nonce)
+                .andReturn();
+
+        String code = parseRedirectQueryString(authorizationResult)
+                .get("code");
+
+        MvcResult tokenResult = performTokenRequest(clientId, redirectUri, codeVerifier, code)
+                .andReturn();
+
+        String accessTokenValue = jwtDecoder
+                .decode((String) parsePayloadFields(tokenResult).get("access_token"))
+                .getTokenValue();
+
+        // when & then
+        mockMvc
+                .perform(
+                        post("/oauth2/introspect")
+                                .contentType(APPLICATION_FORM_URLENCODED)
+                                .param("client_id", clientId)
+                                .param("code", code)
+                                .param("code_verifier", codeVerifier)
+                                .param("grant_type", "authorization_code")
+                                .param("redirect_uri", redirectUri)
+                                .param("token", accessTokenValue)
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document(
+                                "introspect",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                requestHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                requestParameters(
+                                        parameterWithName("client_id").description("클라이언트 id"),
+                                        parameterWithName("code").description("인가 코드"),
+                                        parameterWithName("code_verifier").description("해시 원본 값"),
+                                        parameterWithName("grant_type").description("인증 방식, authorization_code 고정으로 사용"),
+                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri"),
+                                        parameterWithName("token").description("엑세스 토큰")
+                                ),
+                                responseHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                responseFields(
+                                        fieldWithPath("active").description("엑세스 토큰의 유효 여부"),
+                                        fieldWithPath("sub").description("인가 요청자"),
+                                        fieldWithPath("aud").description("인가 클라이언트"),
+                                        fieldWithPath("nbf").description("엑세스 토큰이 활성화된 시간(unix time)"),
+                                        fieldWithPath("scope").description("엑세스 토큰의 인가 범위"),
+                                        fieldWithPath("iss").description("엑세스 토큰 발행자"),
+                                        fieldWithPath("exp").description("엑세스 토큰이 만료되는 시간(unix time)"),
+                                        fieldWithPath("iat").description("엑세스 토큰이 발행된 시간(unix time)"),
+                                        fieldWithPath("client_id").description("클라이언트 id"),
+                                        fieldWithPath("token_type").description("토큰 타입, Bearer 고정으로 사용")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName(value = "revoke")
+    void revoke() throws Exception {
+        // given
+        String clientId = publicClient.getClientId();
+        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
+        String scope = join(" ", publicClient.getScopes());
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        String state = randomUUID().toString();
+        String nonce = randomUUID().toString();
+
+        MvcResult authorizationResult = performAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, state, nonce)
+                .andReturn();
+
+        String code = parseRedirectQueryString(authorizationResult)
+                .get("code");
+
+        MvcResult tokenResult = performTokenRequest(clientId, redirectUri, codeVerifier, code)
+                .andReturn();
+
+        String accessTokenValue = jwtDecoder
+                .decode((String) parsePayloadFields(tokenResult).get("access_token"))
+                .getTokenValue();
+
+        // when & then
+        mockMvc
+                .perform(
+                        post("/oauth2/revoke")
+                                .contentType(APPLICATION_FORM_URLENCODED)
+                                .param("client_id", clientId)
+                                .param("code", code)
+                                .param("code_verifier", codeVerifier)
+                                .param("grant_type", "authorization_code")
+                                .param("redirect_uri", redirectUri)
+                                .param("token", accessTokenValue)
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document(
+                                "revoke",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                requestHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                requestParameters(
+                                        parameterWithName("client_id").description("클라이언트 id"),
+                                        parameterWithName("code").description("인가 코드"),
+                                        parameterWithName("code_verifier").description("해시 원본 값"),
+                                        parameterWithName("grant_type").description("인증 방식, authorization_code 고정으로 사용"),
+                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri"),
+                                        parameterWithName("token").description("엑세스 토큰")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName(value = "userinfo")
+    void userinfo() throws Exception {
+        // given
+        String clientId = publicClient.getClientId();
+        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
+        String scope = join(" ", publicClient.getScopes());
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        String state = randomUUID().toString();
+        String nonce = randomUUID().toString();
+
+        MvcResult authorizationResult = performAuthorizationRequest(clientId, redirectUri, scope, codeChallenge, state, nonce)
+                .andReturn();
+
+        String code = parseRedirectQueryString(authorizationResult)
+                .get("code");
+
+        MvcResult tokenResult = performTokenRequest(clientId, redirectUri, codeVerifier, code)
+                .andReturn();
+
+        String accessTokenValue = jwtDecoder
+                .decode((String) parsePayloadFields(tokenResult).get("access_token"))
+                .getTokenValue();
+
+        // when & then
+        mockMvc
+                .perform(
+                        get("/userinfo")
+                                .header(AUTHORIZATION, "Bearer " + accessTokenValue)
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document(
+                                "userinfo",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                responseHeaders(
+                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
+                                ),
+                                responseFields(
+                                        fieldWithPath("sub").description("인가 요청자")
+                                )
+                        )
+                );
     }
 
     static RegisteredClient createOauth2PublicClient() {
@@ -70,7 +368,7 @@ class Oauth2AuthorizationTest extends IntegrationTestContext {
         Set<String> allowedCustomScopes = Set.of("user.read", "user.write");
 
         return withId(randomUUID().toString())
-                .clientId("test-public-client")
+                .clientId(randomUUID().toString())
                 .clientAuthenticationMethod(NONE)
                 .authorizationGrantType(AUTHORIZATION_CODE)
                 .redirectUri("http://127.0.0.1:8600/authorized")
@@ -88,9 +386,44 @@ class Oauth2AuthorizationTest extends IntegrationTestContext {
                 .build();
     }
 
-    @BeforeAll
-    static void setUp(@Autowired RegisteredClientRepository registeredClientRepository) {
-        registeredClientRepository.save(publicClient);
+    private ResultActions performAuthorizationRequest(String clientId,
+                                                      String redirectUri,
+                                                      String scope,
+                                                      String codeChallenge,
+                                                      String state,
+                                                      String nonce) throws Exception {
+        return mockMvc.perform(
+                get("/oauth2/authorize")
+                        .with(csrf())
+                        .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", redirectUri)
+                        .queryParam("scope", scope)
+                        .queryParam("response_type", "code")
+                        .queryParam("code_challenge", codeChallenge)
+                        .queryParam("code_challenge_method", "S256")
+                        .queryParam("state", state)
+                        .queryParam("nonce", nonce)
+        )
+                .andExpect(status().is3xxRedirection())
+                .andDo(print());
+    }
+
+    private ResultActions performTokenRequest(String clientId,
+                                              String redirectUri,
+                                              String codeVerifier,
+                                              String code) throws Exception {
+        return mockMvc
+                .perform(
+                        post("/oauth2/token")
+                                .contentType(APPLICATION_FORM_URLENCODED)
+                                .param("client_id", clientId)
+                                .param("code", code)
+                                .param("code_verifier", codeVerifier)
+                                .param("grant_type", "authorization_code")
+                                .param("redirect_uri", redirectUri)
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
     }
 
     private String generateCodeVerifier() {
@@ -143,146 +476,6 @@ class Oauth2AuthorizationTest extends IntegrationTestContext {
 
         return objectMapper.readValue(payload, new TypeReference<>() {
         });
-    }
-
-    @Test
-    @WithMockUser
-    @DisplayName(value = "authorization")
-    void authorization() throws Exception {
-        // given
-        String clientId = publicClient.getClientId();
-        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
-        String scope = join(" ", publicClient.getScopes());
-        String codeVerifier = generateCodeVerifier();
-        String codeChallenge = generateCodeChallenge(codeVerifier);
-        String state = randomUUID().toString();
-        String nonce = randomUUID().toString();
-
-        // when & then
-        MvcResult authorizationResult = mockMvc
-                .perform(
-                        get("/oauth2/authorize")
-                                .with(csrf())
-                                .queryParam("client_id", clientId)
-                                .queryParam("redirect_uri", redirectUri)
-                                .queryParam("scope", scope)
-                                .queryParam("response_type", "code")
-                                .queryParam("code_challenge", codeChallenge)
-                                .queryParam("code_challenge_method", "S256")
-                                .queryParam("state", state)
-                                .queryParam("nonce", nonce)
-                )
-                .andExpect(status().is3xxRedirection())
-                .andDo(print())
-                .andDo(
-                        document(
-                                "authorization",
-                                REQUEST_PREPROCESSOR,
-                                RESPONSE_PREPROCESSOR,
-                                requestParameters(
-                                        parameterWithName("client_id").description("클라이언트 id"),
-                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri"),
-                                        parameterWithName("scope").description("토큰의 인가 범위").optional(),
-                                        parameterWithName("response_type").description("응답 유형, code 고정으로 사용"),
-                                        parameterWithName("code_challenge").description("해시 값, Base64(SHA256(code_verifier))"),
-                                        parameterWithName("code_challenge_method").description("해시 방식, S256 고정으로 사용"),
-                                        parameterWithName("state").description("리다이렉트 callback uri로 전달되는 값").optional(),
-                                        parameterWithName("nonce").description("id_token claim에 포함되는 값").optional()
-                                ),
-                                responseHeaders(
-                                        headerWithName(LOCATION).description(LOCATION)
-                                )
-                        )
-                )
-                .andReturn();
-
-        Map<String, String> queryStrings = parseRedirectQueryString(authorizationResult);
-
-        assertThat(queryStrings.get("state"), is(equalTo(state)));
-        assertThat(queryStrings.get("code"), is(not(emptyOrNullString())));
-    }
-
-    @Test
-    @WithMockUser
-    @DisplayName(value = "token")
-    void token() throws Exception {
-        // given
-        String clientId = publicClient.getClientId();
-        String redirectUri = publicClient.getRedirectUris().stream().findFirst().orElseThrow();
-        String scope = join(" ", publicClient.getScopes());
-        String codeVerifier = generateCodeVerifier();
-        String codeChallenge = generateCodeChallenge(codeVerifier);
-        String state = randomUUID().toString();
-        String nonce = randomUUID().toString();
-
-        // when & then
-        MvcResult authorizationResult = mockMvc
-                .perform(
-                        get("/oauth2/authorize")
-                                .with(csrf())
-                                .queryParam("client_id", clientId)
-                                .queryParam("redirect_uri", redirectUri)
-                                .queryParam("scope", scope)
-                                .queryParam("response_type", "code")
-                                .queryParam("code_challenge", codeChallenge)
-                                .queryParam("code_challenge_method", "S256")
-                                .queryParam("state", state)
-                                .queryParam("nonce", nonce)
-                )
-                .andExpect(status().is3xxRedirection())
-                .andDo(print())
-                .andReturn();
-
-        Map<String, String> queryStrings = parseRedirectQueryString(authorizationResult);
-
-        assertThat(queryStrings.get("state"), is(equalTo(state)));
-        assertThat(queryStrings.get("code"), is(not(emptyOrNullString())));
-
-        MvcResult tokenResult = mockMvc
-                .perform(
-                        post("/oauth2/token")
-                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                                .param("client_id", clientId)
-                                .param("code", queryStrings.get("code"))
-                                .param("code_verifier", codeVerifier)
-                                .param("grant_type", "authorization_code")
-                                .param("redirect_uri", redirectUri)
-                )
-                .andExpect(status().isOk())
-                .andDo(print())
-                .andDo(
-                        document(
-                                "token",
-                                REQUEST_PREPROCESSOR,
-                                RESPONSE_PREPROCESSOR,
-                                requestHeaders(
-                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
-                                ),
-                                requestParameters(
-                                        parameterWithName("client_id").description("클라이언트 id"),
-                                        parameterWithName("code").description("인가 코드"),
-                                        parameterWithName("code_verifier").description("해시 원본 값").optional(),
-                                        parameterWithName("grant_type").description("인증 방식, authorization_code 고정으로 사용"),
-                                        parameterWithName("redirect_uri").description("리다이렉트 callback uri")
-                                ),
-                                responseHeaders(
-                                        headerWithName(CONTENT_TYPE).description(CONTENT_TYPE)
-                                ),
-                                responseFields(
-                                        fieldWithPath("access_token").description("엑세스 토큰"),
-                                        fieldWithPath("scope").description("엑세스 토큰의 인가 범위"),
-                                        fieldWithPath("id_token").description("인증 토큰, 인가 요청시 scope로 openid를 전달한 경우에만 발급").optional(),
-                                        fieldWithPath("token_type").description("토큰 타입, Bearer 고정으로 사용"),
-                                        fieldWithPath("expires_in").description("토큰의 남은 유효기간")
-                                )
-                        )
-                )
-                .andReturn();
-
-        Map<String, Object> fields = parsePayloadFields(tokenResult);
-        Jwt idToken = jwtDecoder.decode((String) fields.get("id_token"));
-
-        assertThat(nonce, is(equalTo(idToken.getClaim("nonce"))));
     }
 
 }

--- a/api-member/src/test/java/com/seeyouletter/api_member/integration/RedisOauth2AuthorizationServiceTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/integration/RedisOauth2AuthorizationServiceTest.java
@@ -1,0 +1,418 @@
+package com.seeyouletter.api_member.integration;
+
+import com.seeyouletter.api_member.IntegrationTestContext;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationCode;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.seeyouletter.api_member.config.RedisOauth2AuthorizationService.*;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.security.MessageDigest.getInstance;
+import static java.time.Instant.now;
+import static java.util.Collections.singletonMap;
+import static java.util.UUID.randomUUID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE;
+import static org.springframework.security.oauth2.core.ClientAuthenticationMethod.NONE;
+import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType.BEARER;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.CODE;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.STATE;
+import static org.springframework.security.oauth2.core.oidc.OidcScopes.*;
+import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.ACCESS_TOKEN;
+import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.REFRESH_TOKEN;
+import static org.springframework.security.oauth2.server.authorization.client.RegisteredClient.withId;
+
+@DisplayName(value = "RedisOauth2AuthorizationService 테스트")
+class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
+
+    private static RegisteredClient publicClient;
+
+    @Autowired
+    private OAuth2AuthorizationService oAuth2AuthorizationService;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @BeforeAll
+    static void setUp(@Autowired RegisteredClientRepository registeredClientRepository) {
+        publicClient = createOauth2PublicClient();
+        registeredClientRepository.save(publicClient);
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        stringRedisTemplate
+                .getConnectionFactory()
+                .getConnection()
+                .flushAll();
+    }
+
+    @Nested
+    @DisplayName(value = "Oauth2Authorization 생성")
+    class Save {
+
+        @Test
+        @DisplayName(value = "Oauth2Authorization(authorization consent state) 생성")
+        void authorizationConsentState() {
+            // given
+            OAuth2Authorization authorization = createOauth2AuthorizationWithConsent();
+
+            // when
+            oAuth2AuthorizationService.save(authorization);
+
+            // then
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_CONSENT_STATE_KEY_PREFIX + authorization.getAttribute(STATE)),
+                    is(true)
+            );
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
+                    is(true)
+            );
+        }
+
+        @Test
+        @DisplayName(value = "Oauth2Authorization(authorization code) 생성")
+        void authorizationCode() {
+            // given
+            OAuth2Authorization authorization = createOauth2AuthorizationWithCode();
+
+            // when
+            oAuth2AuthorizationService.save(authorization);
+
+            String authorizationCodeValue = authorization
+                    .getToken(OAuth2AuthorizationCode.class)
+                    .getToken()
+                    .getTokenValue();
+
+            // then
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue),
+                    is(true)
+            );
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
+                    is(true)
+            );
+        }
+
+        @Test
+        @DisplayName(value = "Oauth2Authorization(authorization tokens) 생성")
+        void authorizationTokens() {
+            // given
+            OAuth2Authorization authorization = createOauth2AuthorizationWithTokens();
+
+            // when
+            oAuth2AuthorizationService.save(authorization);
+
+            String authorizationCodeValue = authorization
+                    .getToken(OAuth2AuthorizationCode.class)
+                    .getToken()
+                    .getTokenValue();
+
+            String accessTokenValue = authorization
+                    .getAccessToken()
+                    .getToken()
+                    .getTokenValue();
+
+            String refreshTokenValue = authorization
+                    .getRefreshToken()
+                    .getToken()
+                    .getTokenValue();
+
+            // then
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue),
+                    is(true)
+            );
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_ACCESS_TOKEN_KEY_PREFIX + encrypt(accessTokenValue)),
+                    is(true)
+            );
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_REFRESH_TOKEN_KEY_PREFIX + encrypt(refreshTokenValue)),
+                    is(true)
+            );
+            assertThat(
+                    stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
+                    is(true)
+            );
+        }
+
+    }
+
+    @Test
+    @DisplayName(value = "Oauth2Authorization 제거")
+    void remove() {
+        // given
+        List<OAuth2Authorization> authorizations = List.of(
+                createOauth2AuthorizationWithConsent(),
+                createOauth2AuthorizationWithCode(),
+                createOauth2AuthorizationWithTokens()
+        );
+
+        authorizations.forEach(oAuth2AuthorizationService::save);
+
+        // when
+        authorizations.forEach(oAuth2AuthorizationService::remove);
+
+        // then
+        authorizations.forEach(authorization ->
+                assertThat(
+                        stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
+                        is(false)
+                )
+        );
+    }
+
+    @Test
+    @DisplayName(value = "Oauth2Authorization id로 조회")
+    void findById() {
+        // given
+        List<OAuth2Authorization> authorizations = List.of(
+                createOauth2AuthorizationWithConsent(),
+                createOauth2AuthorizationWithCode(),
+                createOauth2AuthorizationWithTokens()
+        );
+
+        authorizations.forEach(oAuth2AuthorizationService::save);
+
+        // when & then
+        for (OAuth2Authorization authorization : authorizations) {
+            assertThat(authorization, is(notNullValue()));
+        }
+    }
+
+    @Nested
+    @DisplayName(value = "Oauth2Authorization findByToken")
+    class FindByToken {
+
+        @Test
+        @DisplayName(value = "Oauth2Authorization(authorization consent state) token으로 조회")
+        void authorizationConsentState() {
+            // given
+            OAuth2Authorization authorization = createOauth2AuthorizationWithConsent();
+
+            oAuth2AuthorizationService.save(authorization);
+
+            // when
+            OAuth2Authorization byToken = oAuth2AuthorizationService.findByToken(authorization.getAttribute(STATE), new OAuth2TokenType(STATE));
+
+            // then
+            assertThat(byToken, is(notNullValue()));
+        }
+
+        @Test
+        @DisplayName(value = "Oauth2Authorization(authorization code) token으로 조회")
+        void authorizationCode() {
+            // given
+            OAuth2Authorization authorization = createOauth2AuthorizationWithCode();
+
+            oAuth2AuthorizationService.save(authorization);
+
+            String authorizationCodeValue = authorization
+                    .getToken(OAuth2AuthorizationCode.class)
+                    .getToken()
+                    .getTokenValue();
+
+            // when
+            OAuth2Authorization byToken = oAuth2AuthorizationService.findByToken(authorizationCodeValue, new OAuth2TokenType(CODE));
+
+            // then
+            assertThat(byToken, is(notNullValue()));
+        }
+
+        @Test
+        @DisplayName(value = "Oauth2Authorization(authorization tokens) token으로 조회")
+        void authorizationTokens() {
+            // given
+            OAuth2Authorization authorization = createOauth2AuthorizationWithTokens();
+
+            oAuth2AuthorizationService.save(authorization);
+
+            String accessTokenValue = authorization
+                    .getAccessToken()
+                    .getToken()
+                    .getTokenValue();
+
+            String refreshTokenValue = authorization
+                    .getRefreshToken()
+                    .getToken()
+                    .getTokenValue();
+
+            // when
+            List<OAuth2Authorization> byTokens = Arrays.asList(
+                    oAuth2AuthorizationService.findByToken(accessTokenValue, ACCESS_TOKEN),
+                    oAuth2AuthorizationService.findByToken(accessTokenValue, null),
+                    oAuth2AuthorizationService.findByToken(refreshTokenValue, REFRESH_TOKEN)
+            );
+
+            // then
+            for (OAuth2Authorization byToken : byTokens) {
+                assertThat(byToken, is(notNullValue()));
+            }
+        }
+
+    }
+
+    static RegisteredClient createOauth2PublicClient() {
+        Set<String> allowedOidcScopes = Set.of(OPENID, PROFILE, EMAIL, ADDRESS, PHONE);
+        Set<String> allowedCustomScopes = Set.of("user.read", "user.write");
+
+        return withId(randomUUID().toString())
+                .clientId(randomUUID().toString())
+                .clientAuthenticationMethod(NONE)
+                .authorizationGrantType(AUTHORIZATION_CODE)
+                .redirectUri("http://127.0.0.1:8600/authorized")
+                .scopes(scopes -> {
+                    scopes.addAll(allowedOidcScopes);
+                    scopes.addAll(allowedCustomScopes);
+                })
+                .clientSettings(
+                        ClientSettings
+                                .builder()
+                                .requireProofKey(true)
+                                .requireAuthorizationConsent(false)
+                                .build()
+                )
+                .build();
+    }
+
+    private OAuth2Authorization createOauth2AuthorizationWithConsent() {
+        return OAuth2Authorization
+                .withRegisteredClient(publicClient)
+                .principalName("user")
+                .authorizationGrantType(AUTHORIZATION_CODE)
+                .attribute(Principal.class.getName(), createPrincipal())
+                .attribute(OAuth2AuthorizationRequest.class.getName(), createOauth2AuthorizationRequest())
+                .attribute(STATE, "l__jFmG5oa5NGiandoVKcVdnYfcX501PpAud1SYF700=")
+                .build();
+    }
+
+    private OAuth2Authorization createOauth2AuthorizationWithCode() {
+        return OAuth2Authorization
+                .withRegisteredClient(publicClient)
+                .principalName("user")
+                .authorizationGrantType(AUTHORIZATION_CODE)
+                .attribute(Principal.class.getName(), createPrincipal())
+                .attribute(OAuth2AuthorizationRequest.class.getName(), createOauth2AuthorizationRequest())
+                .authorizedScopes(Set.of("user.read"))
+                .token(createOauth2AuthorizationCode())
+                .build();
+    }
+
+    private OAuth2Authorization createOauth2AuthorizationWithTokens() {
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                BEARER,
+                "access-token",
+                now(),
+                now().plusSeconds(300),
+                Set.of("user.read")
+        );
+
+        OAuth2RefreshToken refreshToken = new OAuth2RefreshToken(
+                "refresh-token",
+                now(),
+                now().plusSeconds(300)
+        );
+
+        OidcIdToken oidcIdToken = new OidcIdToken(
+                "oidc-token",
+                now(),
+                now().plusSeconds(300),
+                singletonMap("sub", "user")
+        );
+
+        return OAuth2Authorization
+                .withRegisteredClient(publicClient)
+                .principalName("user")
+                .authorizationGrantType(AUTHORIZATION_CODE)
+                .attribute(Principal.class.getName(), createPrincipal())
+                .attribute(OAuth2AuthorizationRequest.class.getName(), createOauth2AuthorizationRequest())
+                .authorizedScopes(Set.of("user.read"))
+                .token(createOauth2AuthorizationCode())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .token(oidcIdToken)
+                .build();
+    }
+
+    private OAuth2AuthorizationCode createOauth2AuthorizationCode() {
+        return new OAuth2AuthorizationCode(
+                randomUUID().toString(),
+                now(),
+                now().plusSeconds(300)
+        );
+    }
+
+    private OAuth2AuthorizationRequest createOauth2AuthorizationRequest() {
+        return OAuth2AuthorizationRequest
+                .authorizationCode()
+                .authorizationUri("http://localhost:8600/oauth2/authorize")
+                .clientId("seeyouletter")
+                .redirectUri("http://127.0.0.1:8600/authorized")
+                .scopes(Set.of("user.read"))
+                .state("123")
+                .additionalParameters(
+                        Map.of(
+                                "code_challenge_method", "S256",
+                                "nonce", "abc",
+                                "code_challenge", "yoxj8-ou9k5pqKXo-yHfhcqcoGYGAiP_bbzerJP1HIg"
+                        )
+                )
+                .build();
+    }
+
+    private UsernamePasswordAuthenticationToken createPrincipal() {
+        return new UsernamePasswordAuthenticationToken(
+                "user",
+                "password",
+                AuthorityUtils.createAuthorityList("ROLE_user.read")
+        );
+    }
+
+    public String encrypt(String token) {
+        MessageDigest messageDigest;
+
+        try {
+            messageDigest = getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+
+        byte[] digest = messageDigest.digest(token.getBytes(UTF_8));
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (byte b : digest) {
+            stringBuilder.append(format("%02x", b));
+        }
+
+        return stringBuilder.toString();
+    }
+
+}

--- a/api-member/src/test/resources/application-test.yml
+++ b/api-member/src/test/resources/application-test.yml
@@ -74,6 +74,7 @@ logging:
     org:
       springframework:
         security: DEBUG
+        security.jackson2: INFO
       hibernate:
         SQL: DEBUG
         type:


### PR DESCRIPTION
## 💌 설명

Spring Authorization Server의 OAuth2AuthorizationService 구현체인 RedisOauth2Authorization Service를 구현합니다. 기본으로 제공하는 `InmemoryOauth2AuthorizationService`는 멀티 애플리케이션 환경에서 애플리케이션 메모리의 상태가 다르기 때문에 사용할 수 없으며 클러스터링이 반드시 필요합니다. 프레임워크에서는 클러스터링을 할 수 있는 구현체로 `JdbcOauth2AuthorizationService`를 제공하지만 그대로 사용하기 보다는 보완하고 싶은 부분들이 있었습니다. 생성 및 삭제는 빈번하나 수정은 빈번하지 않으며, 유효기간이 지난 불필요한 인증 정보들을 삭제하기 위해서는 별도의 스케줄링 작업이 필요합니다. Redis의 TTL(Time To Live)을 활용해서 불필요한 인증 정보를 제거할 수 있고 자료구조를 사용하여 빠르게 조회할 수 있다고 생각하여 작업을 진행했습니다.

- `redis`를 사용하는 `Oauth2AuthorizationService`의 커스텀 구현체를 구현했습니다. 
- 구현체인 `RedisOauth2AuthorizationService`를 테스트하기 위해 integration, e2e 테스트를 작성했습니다.
- key,value를 string으로 더 편리하게 사용하기 위해 `RedisTemplate`에서 `StringRedisTemplate`으로 변경

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
