### PR TITLE
style(test): assertThat 사용하는 테스트 코드 hamcrest에서 assertj로 변경

### DIFF
--- a/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
@@ -68,16 +68,14 @@ public class AuthorizationServerConfiguration {
     public RegisteredClientRepository registeredClientRepository() {
         Set<String> allowedOidcScopes = Set.of(OPENID, PROFILE, EMAIL, ADDRESS, PHONE);
         Set<String> allowedCustomScopes = Set.of("user.read", "user.write");
+        Set<String> allowedRedirectUris = Set.of("http://127.0.0.1:8600/authorized", "https://dev-member.seeyouletter.kr");
+
 
         RegisteredClient registeredClient = withId("98348f89-5433-41a1-b12d-657f4f3d19f9")
                 .clientId("seeyouletter")
                 .clientAuthenticationMethod(NONE)
                 .authorizationGrantType(AUTHORIZATION_CODE)
-                .redirectUris(redirectUris -> {
-                    redirectUris.add("http://127.0.0.1:8600/authorized");
-                    redirectUris.add("http://127.0.0.1:2462/auth/redirect");
-                    redirectUris.add("https://seeyouletter.kr/auth/redirect");
-                })
+                .redirectUris(redirectUris -> redirectUris.addAll(allowedRedirectUris))
                 .scopes(scopes -> {
                     scopes.addAll(allowedOidcScopes);
                     scopes.addAll(allowedCustomScopes);

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
@@ -60,6 +60,7 @@ public class SecurityConfiguration {
         configuration.setAllowedOrigins(
                 asList(
                         "http://localhost:2462",
+                        "http://127.0.0.1:9600",
                         "http://127.0.0.1:2462",
                         "https://seeyouletter.kr"
                 )

--- a/api-member/src/test/java/com/seeyouletter/api_member/e2e/Oauth2AuthorizationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/e2e/Oauth2AuthorizationTest.java
@@ -35,11 +35,9 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.security.MessageDigest.getInstance;
 import static java.util.UUID.randomUUID;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
-import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -120,8 +118,8 @@ class Oauth2AuthorizationTest extends IntegrationTestContext {
 
         Map<String, String> queryStrings = parseRedirectQueryString(authorizationResult);
 
-        assertThat(queryStrings.get("state"), is(equalTo(state)));
-        assertThat(queryStrings.get("code"), is(not(emptyOrNullString())));
+        assertThat(queryStrings.get("state")).isEqualTo(state);
+        assertThat(queryStrings.get("code")).isNotEmpty();
     }
 
     @Test
@@ -177,7 +175,7 @@ class Oauth2AuthorizationTest extends IntegrationTestContext {
         Map<String, Object> fields = parsePayloadFields(tokenResult);
         Jwt idToken = jwtDecoder.decode((String) fields.get("id_token"));
 
-        assertThat(nonce, is(equalTo(idToken.getClaim("nonce"))));
+        assertThat(nonce).isEqualTo(idToken.getClaim("nonce"));
     }
 
     @Test
@@ -397,17 +395,17 @@ class Oauth2AuthorizationTest extends IntegrationTestContext {
                                                       String state,
                                                       String nonce) throws Exception {
         return mockMvc.perform(
-                get("/oauth2/authorize")
-                        .with(csrf())
-                        .queryParam("client_id", clientId)
-                        .queryParam("redirect_uri", redirectUri)
-                        .queryParam("scope", scope)
-                        .queryParam("response_type", "code")
-                        .queryParam("code_challenge", codeChallenge)
-                        .queryParam("code_challenge_method", "S256")
-                        .queryParam("state", state)
-                        .queryParam("nonce", nonce)
-        )
+                        get("/oauth2/authorize")
+                                .with(csrf())
+                                .queryParam("client_id", clientId)
+                                .queryParam("redirect_uri", redirectUri)
+                                .queryParam("scope", scope)
+                                .queryParam("response_type", "code")
+                                .queryParam("code_challenge", codeChallenge)
+                                .queryParam("code_challenge_method", "S256")
+                                .queryParam("state", state)
+                                .queryParam("nonce", nonce)
+                )
                 .andExpect(status().is3xxRedirection())
                 .andDo(print());
     }

--- a/api-member/src/test/java/com/seeyouletter/api_member/integration/RedisOauth2AuthorizationServiceTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/integration/RedisOauth2AuthorizationServiceTest.java
@@ -33,9 +33,7 @@ import static java.security.MessageDigest.getInstance;
 import static java.time.Instant.now;
 import static java.util.Collections.singletonMap;
 import static java.util.UUID.randomUUID;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE;
 import static org.springframework.security.oauth2.core.ClientAuthenticationMethod.NONE;
 import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType.BEARER;
@@ -85,14 +83,8 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
             oAuth2AuthorizationService.save(authorization);
 
             // then
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_CONSENT_STATE_KEY_PREFIX + authorization.getAttribute(STATE)),
-                    is(true)
-            );
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
-                    is(true)
-            );
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_CONSENT_STATE_KEY_PREFIX + authorization.getAttribute(STATE))).isTrue();
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId())).isTrue();
         }
 
         @Test
@@ -110,14 +102,8 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
                     .getTokenValue();
 
             // then
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue),
-                    is(true)
-            );
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
-                    is(true)
-            );
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue)).isTrue();
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId())).isTrue();
         }
 
         @Test
@@ -145,22 +131,10 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
                     .getTokenValue();
 
             // then
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue),
-                    is(true)
-            );
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_ACCESS_TOKEN_KEY_PREFIX + encrypt(accessTokenValue)),
-                    is(true)
-            );
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_REFRESH_TOKEN_KEY_PREFIX + encrypt(refreshTokenValue)),
-                    is(true)
-            );
-            assertThat(
-                    stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
-                    is(true)
-            );
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_CODE_KEY_PREFIX + authorizationCodeValue)).isTrue();
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_ACCESS_TOKEN_KEY_PREFIX + encrypt(accessTokenValue))).isTrue();
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_REFRESH_TOKEN_KEY_PREFIX + encrypt(refreshTokenValue))).isTrue();
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId())).isTrue();
         }
 
     }
@@ -181,12 +155,9 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
         authorizations.forEach(oAuth2AuthorizationService::remove);
 
         // then
-        authorizations.forEach(authorization ->
-                assertThat(
-                        stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId()),
-                        is(false)
-                )
-        );
+        for (OAuth2Authorization authorization : authorizations) {
+            assertThat(stringRedisTemplate.hasKey(AUTHORIZATION_KEY_PREFIX + authorization.getId())).isFalse();
+        }
     }
 
     @Test
@@ -203,7 +174,7 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
 
         // when & then
         for (OAuth2Authorization authorization : authorizations) {
-            assertThat(authorization, is(notNullValue()));
+            assertThat(authorization).isNotNull();
         }
     }
 
@@ -223,7 +194,7 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
             OAuth2Authorization byToken = oAuth2AuthorizationService.findByToken(authorization.getAttribute(STATE), new OAuth2TokenType(STATE));
 
             // then
-            assertThat(byToken, is(notNullValue()));
+            assertThat(byToken).isNotNull();
         }
 
         @Test
@@ -243,7 +214,7 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
             OAuth2Authorization byToken = oAuth2AuthorizationService.findByToken(authorizationCodeValue, new OAuth2TokenType(CODE));
 
             // then
-            assertThat(byToken, is(notNullValue()));
+            assertThat(byToken).isNotNull();
         }
 
         @Test
@@ -273,7 +244,7 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
 
             // then
             for (OAuth2Authorization byToken : byTokens) {
-                assertThat(byToken, is(notNullValue()));
+                assertThat(byToken).isNotNull();
             }
         }
 

--- a/domain-letter/src/test/java/com/seeyouletter/domain_letter/collection/LetterTest.java
+++ b/domain-letter/src/test/java/com/seeyouletter/domain_letter/collection/LetterTest.java
@@ -2,9 +2,7 @@ package com.seeyouletter.domain_letter.collection;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LetterTest {
 
@@ -17,7 +15,7 @@ class LetterTest {
         Letter letter = new Letter(title);
 
         // then
-        assertThat(letter.getTitle(), is(equalTo(title)));
+        assertThat(letter.getTitle()).isEqualTo(title);
     }
 
 }

--- a/domain-letter/src/test/java/com/seeyouletter/domain_letter/repository/LetterRepositoryTest.java
+++ b/domain-letter/src/test/java/com/seeyouletter/domain_letter/repository/LetterRepositoryTest.java
@@ -5,8 +5,7 @@ import com.seeyouletter.domain_letter.collection.Letter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LetterRepositoryTest extends MongoTestContext {
 
@@ -23,8 +22,8 @@ class LetterRepositoryTest extends MongoTestContext {
         letterRepository.save(letter);
 
         // then
-        assertThat(letter.getTitle(), is(equalTo(title)));
-        assertThat(letter.getId(), is(notNullValue()));
+        assertThat(letter.getTitle()).isEqualTo(title);
+        assertThat(letter.getId()).isNotNull();
     }
 
 }

--- a/domain-member/src/test/java/com/seeyouletter/domain_member/entity/UserTest.java
+++ b/domain-member/src/test/java/com/seeyouletter/domain_member/entity/UserTest.java
@@ -6,9 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 class UserTest {
 
@@ -32,10 +31,10 @@ class UserTest {
                 .build();
 
         // then
-        assertThat(user.getEmail(), is(equalTo(email)));
-        assertThat(user.getPhone(), is(equalTo(phone)));
-        assertThat(user.getGenderType(), is(equalTo(genderType)));
-        assertThat(user.getBirth(), is(equalTo(birth)));
+        assertThat(user.getEmail()).isEqualTo(email);
+        assertThat(user.getPhone()).isEqualTo(phone);
+        assertThat(user.getGenderType()).isEqualTo(genderType);
+        assertThat(user.getBirth()).isEqualTo(birth);
     }
 
 }

--- a/domain-member/src/test/java/com/seeyouletter/domain_member/repository/UserRepositoryTest.java
+++ b/domain-member/src/test/java/com/seeyouletter/domain_member/repository/UserRepositoryTest.java
@@ -9,8 +9,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class UserRepositoryTest {
@@ -18,7 +17,7 @@ class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
-    User createUser(){
+    User createUser() {
         String name = "신영진";
         String email = "dev.sinbom@gmail.com";
         String phone = "01011111111";
@@ -34,6 +33,7 @@ class UserRepositoryTest {
                 .regDate(LocalDateTime.now())
                 .build();
     }
+
     @Test
     void save() {
         // given
@@ -43,11 +43,11 @@ class UserRepositoryTest {
         User savedUser = userRepository.save(user);
 
         // then
-        assertThat(savedUser.getEmail(), is(equalTo(user.getEmail())));
-        assertThat(savedUser.getPhone(), is(equalTo(user.getPhone())));
-        assertThat(savedUser.getGenderType(), is(equalTo(user.getGenderType())));
-        assertThat(savedUser.getBirth(), is(equalTo(user.getBirth())));
-        assertThat(savedUser.getId(), is(notNullValue()));
+        assertThat(savedUser.getEmail()).isEqualTo(user.getEmail());
+        assertThat(savedUser.getPhone()).isEqualTo(user.getPhone());
+        assertThat(savedUser.getGenderType()).isEqualTo(user.getGenderType());
+        assertThat(savedUser.getBirth()).isEqualTo(user.getBirth());
+        assertThat(savedUser.getId()).isNotNull();
     }
 
     @Test
@@ -59,7 +59,7 @@ class UserRepositoryTest {
         User foundUser = userRepository.findById(savedUser.getId()).get();
 
         // then
-        assertThat(savedUser.getEmail(), is(equalTo(foundUser.getEmail())));
+        assertThat(savedUser.getEmail()).isEqualTo(foundUser.getEmail());
     }
 
 }


### PR DESCRIPTION
## 💌 설명

`assertThat` 사용하는 테스트 코드 `hamcrest`에서 `assertj`로 변경합니다.
기존에 `assertJ`의 `assertThat` 사용이 더 직관적이고 구체적인 에러 메시지를 출력하기 때문에 `junit`의 `assertThat` 보다 더 낫다는 글들을 접했었습니다. 적용하는 과정에서 `assertJ`의 `assertThat`을 사용했어야 했는데 `hamcrest`의 `assertThat`을 잘못 적용했습니다 😂

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->
- [AssertJ vs Junit](https://annaduldiier.medium.com/assertj-vs-junit-483b7d6dc997)
- [AssertJ 필수 기능 정리](https://steady-coding.tistory.com/351)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
