### PR TITLE
dev profile 네이버, 카카오 callback redirect uri를 수정한다.

### DIFF
--- a/api-member/src/main/resources/application-dev.yml
+++ b/api-member/src/main/resources/application-dev.yml
@@ -30,7 +30,7 @@ spring:
             clientSecret: ENC(FSm1doVFr2RG97uyspaJpI9/qkAl21mz)
             clientAuthenticationMethod: post
             authorizationGrantType: authorization_code
-            redirectUri: http://localhost:8600/login/oauth2/code/naver
+            redirectUri: https://dev-member.seeyouletter.kr/login/oauth2/code/naver
             scope:
               - nickname
               - email
@@ -45,7 +45,7 @@ spring:
             clientSecret: ENC(rNGXN3onQN+TLtHB+a8HTD6l6aF5Jj0m3UNdOjwqoGFeJ3O/OygGA3gg+smPZKR7)
             clientAuthenticationMethod: post
             authorizationGrantType: authorization_code
-            redirectUri: http://localhost:8600/login/oauth2/code/kakao
+            redirectUri: https://dev-member.seeyouletter.kr/login/oauth2/code/kakao
             scope:
               - profile_nickname
               - account_email

--- a/api-member/src/main/resources/application-local.yml
+++ b/api-member/src/main/resources/application-local.yml
@@ -28,7 +28,7 @@ spring:
             clientSecret: ENC(FSm1doVFr2RG97uyspaJpI9/qkAl21mz)
             clientAuthenticationMethod: post
             authorizationGrantType: authorization_code
-            redirectUri: http://localhost:8600/login/oauth2/code/naver
+            redirectUri: http://localhost:${server.port}/login/oauth2/code/naver
             scope:
               - nickname
               - email
@@ -43,7 +43,7 @@ spring:
             clientSecret: ENC(rNGXN3onQN+TLtHB+a8HTD6l6aF5Jj0m3UNdOjwqoGFeJ3O/OygGA3gg+smPZKR7)
             clientAuthenticationMethod: post
             authorizationGrantType: authorization_code
-            redirectUri: http://localhost:8600/login/oauth2/code/kakao
+            redirectUri: http://localhost:${server.port}/login/oauth2/code/kakao
             scope:
               - profile_nickname
               - account_email


### PR DESCRIPTION
## 💌 설명

개발 서버에서 사용할 네이버, 카카오 callback redirect uri를 알맞게 수정합니다.
네이버, 카카오 애플리케이션에서 redirect_uri 설정도 동일하게 변경했습니다.

### 네이버
<img width="888" alt="스크린샷 2023-02-18 오후 2 50 08" src="https://user-images.githubusercontent.com/52724515/219843657-18988a3f-0de8-4662-8a7d-5bf34f98f7da.png">

### 카카오
<img width="969" alt="스크린샷 2023-02-18 오후 2 50 28" src="https://user-images.githubusercontent.com/52724515/219843662-394cda0e-95e0-479f-8863-e421143c67a7.png">


## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
