### PR TITLE
chore(api-member): dev 환경에서 임시 admin 계정 정보 insert 적용

### DIFF
--- a/api-member/src/main/resources/application-dev.yml
+++ b/api-member/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## 💌 설명

개발 서버에서  어플리케이션 실행 시 sql문 수행하여 임시 admin계정으로 로그인 할 수 있도록 적용했습니다.
추후에 JPA ddl-auto 설정이 변경되거나 회원가입 로직 추가 시(가입을 매번 해야하는 번거로움이 있다면 그냥 두어도 될것 같습니닷) 삭제예정입니다.

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
