### PR TITLE
feat(api-member): rest API 로그인 추가 적용

### DIFF
--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomHttpConfigurer.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomHttpConfigurer.java
@@ -1,0 +1,26 @@
+package com.seeyouletter.api_member.auth.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class CustomHttpConfigurer extends AbstractHttpConfigurer<CustomHttpConfigurer, HttpSecurity> {
+
+    private final ObjectMapper objectMapper;
+
+    private CustomHttpConfigurer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+        http.addFilterBefore(new RestAuthenticationProcessingFilter(authenticationManager, objectMapper), UsernamePasswordAuthenticationFilter.class);
+    }
+
+    public static CustomHttpConfigurer customHttpConfigurer(ObjectMapper objectMapper) {
+        return new CustomHttpConfigurer(objectMapper);
+    }
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/config/RestAuthenticationProcessingFilter.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/config/RestAuthenticationProcessingFilter.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.MimeTypeUtils;
 
 import javax.servlet.FilterChain;
@@ -24,8 +25,8 @@ import java.io.IOException;
 @Slf4j
 public class RestAuthenticationProcessingFilter extends AbstractAuthenticationProcessingFilter {
 
-    private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = new AntPathRequestMatcher("/login",
-            "POST");
+    public static final String REST_LOGIN_PATTERN = "/login";
+    private static final RequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = new AntPathRequestMatcher(REST_LOGIN_PATTERN, "POST");
 
     private final ObjectMapper objectMapper;
 

--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/config/RestAuthenticationProcessingFilter.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/config/RestAuthenticationProcessingFilter.java
@@ -1,0 +1,75 @@
+package com.seeyouletter.api_member.auth.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seeyouletter.api_member.auth.value.LoginRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.MimeTypeUtils;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class RestAuthenticationProcessingFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = new AntPathRequestMatcher("/login",
+            "POST");
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationProcessingFilter(AuthenticationManager authenticationManager, ObjectMapper objectMapper) {
+        super(DEFAULT_ANT_PATH_REQUEST_MATCHER, authenticationManager);
+        this.objectMapper = objectMapper;
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if(MimeTypeUtils.APPLICATION_JSON_VALUE.equals(request.getContentType())){
+            super.doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+        }else{
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        if (!HttpMethod.POST.name().equals(request.getMethod())) {
+            throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
+        }
+        LoginRequest loginRequest = obtainLoginRequest(request);
+
+        UsernamePasswordAuthenticationToken authenticationToken = UsernamePasswordAuthenticationToken
+                .unauthenticated(loginRequest.getUsername(), loginRequest.getPassword());
+
+        setDetails(request, authenticationToken);
+
+        return this.getAuthenticationManager().authenticate(authenticationToken);
+    }
+
+    private LoginRequest obtainLoginRequest(HttpServletRequest request){
+        try {
+            return objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+        }catch (IOException e){
+            log.error(e.getMessage());
+            throw new AuthenticationServiceException("Login Request parsing error");
+        }
+    }
+
+    private void setDetails(HttpServletRequest request, UsernamePasswordAuthenticationToken authRequest) {
+        authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+    }
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/value/LoginRequest.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/value/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.seeyouletter.api_member.auth.value;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginRequest {
+
+    private String username;
+    private String password;
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.seeyouletter.api_member.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seeyouletter.api_member.auth.config.RestAuthenticationProcessingFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -35,7 +36,7 @@ public class SecurityConfiguration {
                 .configurationSource(corsConfigurationSource())
                 .and()
                 .csrf()
-                .ignoringAntMatchers("/login")
+                .ignoringAntMatchers(RestAuthenticationProcessingFilter.REST_LOGIN_PATTERN)
                 .and()
                 .authorizeRequests()
                 .mvcMatchers("/authorized").permitAll()


### PR DESCRIPTION
## 💌 설명
Rest API 로그인을 추가했습니다.
로그인 API 명세는 노션을 참고해주세요

- `AbstractAuthenticationProcessingFilter`을 상속받아 FormLogin을 수행하는 `UsernameAuthenticationProcessingFilter` 를 참고했습니다.
- 동일한 클래스를 상속받아 Rest API 요청시 `Authentication`를 리턴하는 `RestAuthenticationProcessingFilter` 를 구현했습니다.
- 각 필터가 독립적이기 때문에 FormLogin과 Login API 모두 사용가능합니다.

## 📎 관련 이슈

closes #42 

## 💡 논의해볼 사항

`SuccessHandler`와 `FailHandler`는 이후에 추가할 것인데 로그인성공 여부만 간단히 응답하면될 것 같아 일단 저의 생각은 `HttpStatus 응답코드`로 리턴하는게 나을 것 같습니다.
(이번 PR버전에서는 아직 "/"로 리다이렉트 되고있습니다.)
@JengYoung 혹시 다른 의견 있으시면 코멘트 부탁드려요!

## 📝 참고자료

- [CustomHttpConfigurer 적용](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)
- [CustomHttpConfigurer 적용 토리맘](https://godekdls.github.io/Spring%20Security/javaconfiguration/#164-custom-dsls)
- [Abstractauthenticationprocessingfilter](https://godekdls.github.io/Spring%20Security/authentication/#109-abstractauthenticationprocessingfilter)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
