### PR TITLE
CustomOauth2User 객체를 RedisOauth2AuthorizationService에서 JSON 역직렬화를 할 수 없는 문제를 해결한다. 

### DIFF
--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomAuthorization.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomAuthorization.java
@@ -1,0 +1,75 @@
+package com.seeyouletter.api_member.auth.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+public class CustomAuthorization {
+
+    @Id
+    private String id;
+
+    private String registeredClientId;
+
+    private String principalName;
+
+    private String authorizationGrantType;
+
+    private Set<String> authorizedScopes;
+
+    private Map<String, Object> attributes;
+
+    private String state;
+
+    private String authorizationCodeValue;
+
+    private Instant authorizationCodeIssuedAt;
+
+    private Instant authorizationCodeExpiresAt;
+
+    private Map<String, Object> authorizationCodeMetadata;
+
+    private String accessTokenValue;
+
+    private Instant accessTokenIssuedAt;
+
+    private Instant accessTokenExpiresAt;
+
+    private Map<String, Object> accessTokenMetadata;
+
+    private String accessTokenType;
+
+    private Set<String> accessTokenScopes;
+
+    private String refreshTokenValue;
+
+    private Instant refreshTokenIssuedAt;
+
+    private Instant refreshTokenExpiresAt;
+
+    private Map<String, Object> refreshTokenMetadata;
+
+    private String oidcIdTokenValue;
+
+    private Instant oidcIdTokenIssuedAt;
+
+    private Instant oidcIdTokenExpiresAt;
+
+    private Map<String, Object> oidcIdTokenMetadata;
+
+    private Map<String, Object> oidcIdTokenClaims;
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomAuthorizationMixIn.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomAuthorizationMixIn.java
@@ -1,0 +1,25 @@
+package com.seeyouletter.api_member.auth.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
+@JsonTypeInfo(use = CLASS)
+@JsonAutoDetect(
+        fieldVisibility = ANY,
+        getterVisibility = NONE,
+        isGetterVisibility = NONE
+)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class CustomAuthorizationMixIn {
+
+    @JsonCreator
+    CustomAuthorizationMixIn() {
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomOauth2UserMixIn.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/config/CustomOauth2UserMixIn.java
@@ -1,0 +1,28 @@
+package com.seeyouletter.api_member.auth.config;
+
+import com.fasterxml.jackson.annotation.*;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
+@JsonTypeInfo(use = CLASS)
+@JsonAutoDetect(
+        fieldVisibility = ANY,
+        getterVisibility = NONE,
+        isGetterVisibility = NONE
+)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class CustomOauth2UserMixIn {
+
+    @JsonCreator
+    CustomOauth2UserMixIn(@JsonProperty(value = "authorities") Collection<? extends GrantedAuthority> authorities,
+                          @JsonProperty(value = "attributes") Map<String, Object> attributes,
+                          @JsonProperty(value = "username") String username) {
+    }
+
+}

--- a/api-member/src/test/java/com/seeyouletter/api_member/config/WithMockOauth2User.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/config/WithMockOauth2User.java
@@ -1,0 +1,47 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.springframework.security.test.context.support.TestExecutionEvent.TEST_METHOD;
+
+@Target(value = {METHOD, TYPE})
+@Retention(value = RUNTIME)
+@Inherited
+@Documented
+@WithSecurityContext(factory = WithMockOauth2UserSecurityContextFactory.class)
+public @interface WithMockOauth2User {
+
+    String value() default "user";
+
+    String username() default "";
+
+    String[] roles() default {"USER"};
+
+    String[] authorities() default {};
+
+    String clientRegistrationId() default "client";
+
+    AttributeKeyPair[] attributes() default {};
+
+    @AliasFor(annotation = WithSecurityContext.class)
+    TestExecutionEvent setupBefore() default TEST_METHOD;
+
+    @interface AttributeKeyPair {
+
+        String key();
+
+        String value();
+
+    }
+
+}

--- a/api-member/src/test/java/com/seeyouletter/api_member/config/WithMockOauth2UserSecurityContextFactory.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/config/WithMockOauth2UserSecurityContextFactory.java
@@ -1,0 +1,91 @@
+package com.seeyouletter.api_member.config;
+
+import com.seeyouletter.api_member.auth.config.CustomOAuth2User;
+import com.seeyouletter.api_member.config.WithMockOauth2User.AttributeKeyPair;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.util.Assert;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.springframework.util.StringUtils.hasLength;
+
+public class WithMockOauth2UserSecurityContextFactory implements WithSecurityContextFactory<WithMockOauth2User> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockOauth2User withUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        context.setAuthentication(createAuthentication(withUser));
+
+        return context;
+    }
+
+    private String getUsername(WithMockOauth2User withUser) {
+        if (hasLength(withUser.username())) {
+            return withUser.username();
+        }
+
+        Assert.notNull(withUser.value(), () -> withUser + " cannot have null username on both username and value properties");
+
+        return withUser.value();
+    }
+
+    private List<GrantedAuthority> createGrantedAuthorities(WithMockOauth2User withUser) {
+        List<GrantedAuthority> grantedAuthorities = Arrays
+                .stream(withUser.authorities())
+                .map(SimpleGrantedAuthority::new)
+                .collect(toList());
+
+        if (grantedAuthorities.isEmpty()) {
+            for (String role : withUser.roles()) {
+                Assert.isTrue(!role.startsWith("ROLE_"), () -> "roles cannot start with ROLE_ Got " + role);
+
+                grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+            }
+        }
+
+        return grantedAuthorities;
+    }
+
+    private Map<String, Object> createAttributes(WithMockOauth2User withUser) {
+        Map<String, Object> attributes = Arrays
+                .stream(withUser.attributes())
+                .collect(
+                        Collectors.toMap(
+                                AttributeKeyPair::key,
+                                AttributeKeyPair::value
+                        )
+                );
+
+        if (attributes.isEmpty()) {
+            attributes.put("id", getUsername(withUser));
+        }
+
+        return attributes;
+    }
+
+    private Authentication createAuthentication(WithMockOauth2User withUser) {
+        if (!(withUser.roles().length == 1 && "USER".equals(withUser.roles()[0]))) {
+            throw new IllegalStateException("You cannot define roles attribute " + asList(withUser.roles())
+                    + " with authorities attribute " + asList(withUser.authorities()));
+        }
+
+        List<GrantedAuthority> grantedAuthorities = createGrantedAuthorities(withUser);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(grantedAuthorities, createAttributes(withUser), getUsername(withUser));
+
+        return new OAuth2AuthenticationToken(customOAuth2User, grantedAuthorities, withUser.clientRegistrationId());
+    }
+
+
+}


### PR DESCRIPTION
## 💌 설명

~~`RedisOauth2AuthorizationService`에서 사용하는 `ObjectMapper`가 `PrincipalDetails`를 JSON 역직렬화를 수행할 수 있도록 mixIn 추가합니다.
테스트 코드에서 사용하는 `@WithMockUser`는 `PrinciaplDetails`가 아닌 다른 `UserDetails` 구현체를 사용하므로 실제로는 테스트가 실패했어야 하는 상황에서 통과할 수 있었습니다. 테스트 환경에서 mock 인증 객체를 사용하더라도 `PrincipalDetails`를 사용하도록 커스텀한 애노테이션과 객체를 주입하는 팩토리를 구현했습니다.~~

**(23.03.01) [해당 PR 작업](https://github.com/seeyouletter/seeyouletter-be/pull/47)으로 인해 `PrincipalDetails` 객체가 제거되고 `UserDetails`, `Oauth2User` 구현체를 분리해서 사용하도록 변경되었습니다. `UserDetails` 구현체는 스프링에서 지원하는 기본 구현체 `User`를 사용하도록 변경되었지만 `Oauth2User`는 기본 구현체인  `DefaultOauth2User`는 Oauth2 Provider마다 다른 엑세스 토큰 발급 API 응답 구조로 인해 특정 필드를 가져와서 사용하기 어려운 방식으로 구현되어 있어 사용하지 않고 커스텀한 구현체인 `CustomOauth2User`을 사용하도록 적용되었습니다. 따라서 커스텀 구현체인  `CustomOauth2User` 역직렬화하기 위한 mixIn을 추가하고 테스트 코드를 보완하는 작업을 했습니다.**

## 📎 관련 이슈

close #44

## 💡 논의해볼 사항

현재 `PrincipalDetail` 클래스에 JPA Entity 클래스인 `User`가 필드로 정의되어 있습니다. 때문에 `User` 클래스 또한 mxIn을 추가해둔 상태인데 현재 PR 작업에서 `User` 필드 제거 작업을 하지는 않았지만 엔티티가 직렬화/역직렬화에 노출되고 있기 때문에 `User` 객체에서 실제로 값을 사용하는 필드들만 사용하거나 dto 객체로 변환해서 사용할 필요가 있습니다. @bulmandu 이에 대해서 의견 공유해주세요 🙇‍♂️

## 📝 참고자료

- [SecurityJackson2Modules - 스프링 시큐리티 관련 객체를 ObjectMapper가 역직렬화 할 수 있도록 지원하는 모듈](https://github.com/spring-projects/spring-security/blob/main/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java)
- [SecurityJackson2Modules - 허용된 객체만을 역직렬화하도록 검증하는 로직](https://github.com/spring-projects/spring-security/blob/be2958ed13698fa65aa552f3df71735c0107eed4/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java#L276-L289)
- [Oauth2AuthorizationServerJackson2Module - 스프링 시큐리티 oauth2 authorziation 관련 객체를 ObjectMapper가 역직렬화 할 수 있도록 지원하는 모듈](https://github.com/spring-projects/spring-authorization-server/blob/main/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2Module.java)
- [WithMockUserSecurityContextFactory - 스프링 시큐리티 테스트 환경에서 mock 인증 객체를 주입하는 팩토리](https://github.com/spring-projects/spring-security/blob/main/test/src/main/java/org/springframework/security/test/context/support/WithMockUserSecurityContextFactory.java)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
