### PR TITLE
oauth2 authorization server userinfo endpoint 응답 필드를 추가한다.

### DIFF
--- a/api-letter/src/test/java/com/seeyouletter/api_letter/IntegrationTestContext.java
+++ b/api-letter/src/test/java/com/seeyouletter/api_letter/IntegrationTestContext.java
@@ -115,6 +115,7 @@ public abstract class IntegrationTestContext {
                         "X-XSS-Protection",
                         "X-Frame-Options",
                         "Pragma",
+                        VARY,
                         CACHE_CONTROL,
                         EXPIRES,
                         CONTENT_LENGTH

--- a/api-member/src/docs/asciidoc/oauth2-authorization-server.adoc
+++ b/api-member/src/docs/asciidoc/oauth2-authorization-server.adoc
@@ -32,6 +32,8 @@ NOTE: 2023-01-25 작성일 기준으로 `public-client` 인 SPA에서만 서비�
 | address | 주소(OIDC scope)
 |===
 
+`OIDC` scope에 대해서는 link:https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse[해당 문서]를 참고해주세요.
+
 === HTTP request
 include::{snippets}/authorization/http-request.adoc[]
 
@@ -116,7 +118,9 @@ include::{snippets}/revoke/http-response.adoc[]
 
 인증 서버에서 토큰을 발급한 유저의 정보를 조회합니다.
 
-NOTE: 유저 정보에 대한 명세를 구체화함에 따라 응답 필드는 지속적으로 추가될 예정입니다.
+`OIDC` standard claims에 대해서는 link:https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims[해당 문서]를 참고해주세요.
+
+NOTE: 유저 정보에 대한 명세를 구체화함에 따라 응답 필드는 지속적으로 추가될 수 있습니다.
 
 === HTTP request
 include::{snippets}/userinfo/http-request.adoc[]

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/AuthorizationServerConfiguration.java
@@ -10,7 +10,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
-import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
@@ -20,8 +19,6 @@ import org.springframework.security.oauth2.server.authorization.config.annotatio
 import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
-import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
-import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -38,8 +35,6 @@ import static org.springframework.security.config.Customizer.withDefaults;
 import static org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE;
 import static org.springframework.security.oauth2.core.ClientAuthenticationMethod.NONE;
 import static org.springframework.security.oauth2.core.oidc.OidcScopes.*;
-import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames.ID_TOKEN;
-import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.ACCESS_TOKEN;
 import static org.springframework.security.oauth2.server.authorization.client.RegisteredClient.withId;
 import static org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration.applyDefaultSecurity;
 
@@ -139,27 +134,6 @@ public class AuthorizationServerConfiguration {
         return AuthorizationServerSettings
                 .builder()
                 .build();
-    }
-
-    @Bean
-    public OAuth2TokenCustomizer<JwtEncodingContext> oAuth2TokenCustomizer() {
-        return context -> {
-            JwtClaimsSet.Builder claims = context.getClaims();
-
-            if (context.getTokenType().equals(ACCESS_TOKEN)) {
-                String name = context
-                        .getPrincipal()
-                        .getName();
-
-                claims.claim("sub", name);
-
-                return;
-            }
-
-            if (context.getTokenType().getValue().equals(ID_TOKEN)) {
-                // TODO Customize claims for id_token
-            }
-        };
     }
 
 }

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/CustomOauth2TokenCustomizer.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/CustomOauth2TokenCustomizer.java
@@ -1,0 +1,103 @@
+package com.seeyouletter.api_member.config;
+
+import com.seeyouletter.api_member.service.UserService;
+import com.seeyouletter.domain_member.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.PHONE_NUMBER_VERIFIED;
+import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames.ID_TOKEN;
+import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.ACCESS_TOKEN;
+import static org.springframework.util.StringUtils.hasText;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOauth2TokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext> {
+
+    private final UserService userService;
+
+    @Override
+    public void customize(JwtEncodingContext context) {
+        JwtClaimsSet.Builder claims = context.getClaims();
+
+        String email = context
+                .getPrincipal()
+                .getName();
+
+        if (context.getTokenType().equals(ACCESS_TOKEN)) {
+            claims.claim("sub", email);
+
+            return;
+        }
+
+        if (context.getTokenType().getValue().equals(ID_TOKEN)) {
+            User user = userService.findByEmail(email);
+
+            Map<String, Object> oidcClaims = OidcUserInfo
+                    .builder()
+                    .subject(user.getEmail())
+                    .preferredUsername(email) // TODO 사용되는 이름으로 변경
+                    .name(user.getName())
+                    .nickname(user.getName()) // TODO 닉네임으로 변경
+                    .profile(getProfile(user))
+                    .birthdate(getBirthdate(user))
+                    .gender(user.getGenderType().name())
+                    .email(user.getEmail())
+                    .emailVerified(getEmailVerified(user))
+                    .phoneNumber(getPhone(user))
+                    .claim(PHONE_NUMBER_VERIFIED, getPhoneVerified(user))
+                    .build()
+                    .getClaims();
+
+            claims.claims(i -> i.putAll(oidcClaims));
+        }
+    }
+
+    private String getBirthdate(User user) {
+        if (user.getBirth() == null) {
+            return null;
+        }
+
+        return user
+                .getBirth()
+                .toString();
+    }
+
+    private String getPhone(User user) {
+        if (!hasText(user.getPhone())) {
+            return null;
+        }
+
+        return user.getPhone();
+    }
+
+    private boolean getPhoneVerified(User user) {
+        if (!hasText(user.getPhone())) {
+            return false;
+        }
+
+        // TODO 휴대폰 검증 여부 판단은 추후 비즈니스 로직에 따라 다를 수 있음
+        return true;
+    }
+
+    private boolean getEmailVerified(User user) {
+        // TODO 이메일 검증 여부 판단은 추후 비즈니스 로직에 따라 다를 수 있음
+        return true;
+    }
+
+    private String getProfile(User user) {
+        if (!hasText(user.getProfileImage())) {
+            // TODO 기본 이미지 프로필 설정
+            return "https://url.kr/e7imr8";
+        }
+
+        return user.getProfileImage();
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/exception/ResourceNotFoundException.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/exception/ResourceNotFoundException.java
@@ -1,0 +1,9 @@
+package com.seeyouletter.api_member.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/service/UserService.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/service/UserService.java
@@ -1,0 +1,23 @@
+package com.seeyouletter.api_member.service;
+
+import com.seeyouletter.api_member.exception.ResourceNotFoundException;
+import com.seeyouletter.domain_member.entity.User;
+import com.seeyouletter.domain_member.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User findByEmail(String email) {
+        return userRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 계정입니다."));
+    }
+
+}

--- a/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
@@ -82,6 +82,7 @@ public abstract class IntegrationTestContext {
                         "X-XSS-Protection",
                         "X-Frame-Options",
                         "Pragma",
+                        VARY,
                         CACHE_CONTROL,
                         EXPIRES,
                         CONTENT_LENGTH

--- a/api-member/src/test/java/com/seeyouletter/api_member/integration/RedisOauth2AuthorizationServiceTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/integration/RedisOauth2AuthorizationServiceTest.java
@@ -47,7 +47,7 @@ import static org.springframework.security.oauth2.server.authorization.client.Re
 @DisplayName(value = "RedisOauth2AuthorizationService 테스트")
 class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
 
-    private static RegisteredClient publicClient;
+    private static final RegisteredClient publicClient = createOauth2PublicClient();
 
     @Autowired
     private OAuth2AuthorizationService oAuth2AuthorizationService;
@@ -56,13 +56,12 @@ class RedisOauth2AuthorizationServiceTest extends IntegrationTestContext {
     private StringRedisTemplate stringRedisTemplate;
 
     @BeforeAll
-    static void setUp(@Autowired RegisteredClientRepository registeredClientRepository) {
-        publicClient = createOauth2PublicClient();
+    static void beforeAll(@Autowired RegisteredClientRepository registeredClientRepository) {
         registeredClientRepository.save(publicClient);
     }
 
     @BeforeEach
-    void cleanUp() {
+    void beforeEach() {
         stringRedisTemplate
                 .getConnectionFactory()
                 .getConnection()


### PR DESCRIPTION
## 💌 설명

Oauth2 authorization server userinfo endpoint 응답 필드를 추가합니다.

## 📎 관련 이슈

closed #43 

## 💡 논의해볼 사항

## 📝 참고자료

[OIDC - Standard Claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
