### PR TITLE
클라이언트는 Third Party 로그인 이후 클라이언트에서 원하는 URL로 리다이렉트할 수 있다.

### DIFF
--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/config/Oauth2ClientAuthorizationRequestSaveContinueUrlFilter.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/config/Oauth2ClientAuthorizationRequestSaveContinueUrlFilter.java
@@ -1,0 +1,115 @@
+package com.seeyouletter.api_member.auth.config;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
+import static org.springframework.util.StringUtils.hasText;
+
+public class Oauth2ClientAuthorizationRequestSaveContinueUrlFilter extends OncePerRequestFilter {
+
+    private static final String REGISTRATION_ID_URI_VARIABLE_NAME = "registrationId";
+
+    public static final String REDIRECT_URI_PARAMETER_NAME = "continue";
+
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    private final AntPathRequestMatcher authorizationRequestMatcher;
+
+    private final List<String> allowOrigins;
+
+    public Oauth2ClientAuthorizationRequestSaveContinueUrlFilter(ClientRegistrationRepository clientRegistrationRepository) {
+        this(clientRegistrationRepository, emptyList(), DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+    }
+
+    public Oauth2ClientAuthorizationRequestSaveContinueUrlFilter(ClientRegistrationRepository clientRegistrationRepository,
+                                                                 List<String> allowOrigins) {
+        this(clientRegistrationRepository, allowOrigins, DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+    }
+
+    public Oauth2ClientAuthorizationRequestSaveContinueUrlFilter(ClientRegistrationRepository clientRegistrationRepository,
+                                                                 List<String> allowOrigins,
+                                                                 String authorizationRequestBaseUri) {
+        Assert.notNull(clientRegistrationRepository, "clientRegistrationRepository cannot be null");
+        Assert.notNull(allowOrigins, "allowOrigins cannot be null");
+        Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri cannot be empty");
+
+        this.clientRegistrationRepository = clientRegistrationRepository;
+        this.authorizationRequestMatcher = new AntPathRequestMatcher(authorizationRequestBaseUri + "/{" + REGISTRATION_ID_URI_VARIABLE_NAME + "}");
+        this.allowOrigins = allowOrigins
+                .stream()
+                .filter(Objects::nonNull)
+                .map(this::trimTrailingSlash)
+                .collect(toUnmodifiableList());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (matchAuthorizationRequest(request)) {
+            saveContinueUrl(request);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean matchAuthorizationRequest(HttpServletRequest request) {
+        if (!authorizationRequestMatcher.matches(request)) {
+            return false;
+        }
+
+        String registrationId = authorizationRequestMatcher
+                .matcher(request)
+                .getVariables()
+                .get(REGISTRATION_ID_URI_VARIABLE_NAME);
+
+        return clientRegistrationRepository.findByRegistrationId(registrationId) != null;
+    }
+
+    private void saveContinueUrl(HttpServletRequest request) {
+        String continueUrl = request.getParameter(REDIRECT_URI_PARAMETER_NAME);
+
+        if (!hasText(continueUrl)) {
+            return;
+        }
+
+        if (!isAllowedOrigin(continueUrl)) {
+            return;
+        }
+
+        request
+                .getSession()
+                .setAttribute(REDIRECT_URI_PARAMETER_NAME, continueUrl);
+    }
+
+    private boolean isAllowedOrigin(String continueUrl) {
+        for (String allowOrigin : allowOrigins) {
+            if (continueUrl.startsWith(allowOrigin)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private String trimTrailingSlash(String origin) {
+        if (origin.endsWith("/")) {
+            return origin.substring(0, origin.length() - 1);
+        }
+
+        return origin;
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/FirstPartyClientProperties.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/FirstPartyClientProperties.java
@@ -1,0 +1,18 @@
+package com.seeyouletter.api_member.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "first.party.client")
+@RequiredArgsConstructor
+public class FirstPartyClientProperties {
+
+    private final List<String> origins;
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/Oauth2ClientRedirectContinueUrlAuthenticationFailureHandler.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/Oauth2ClientRedirectContinueUrlAuthenticationFailureHandler.java
@@ -1,0 +1,90 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+import static com.seeyouletter.api_member.auth.config.Oauth2ClientAuthorizationRequestSaveContinueUrlFilter.REDIRECT_URI_PARAMETER_NAME;
+import static org.springframework.security.oauth2.core.OAuth2ErrorCodes.SERVER_ERROR;
+import static org.springframework.util.StringUtils.hasText;
+import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
+
+public class Oauth2ClientRedirectContinueUrlAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private static final String DEFAULT_FAILURE_URL = "/login";
+
+    public Oauth2ClientRedirectContinueUrlAuthenticationFailureHandler() {
+        this(DEFAULT_FAILURE_URL);
+    }
+
+    public Oauth2ClientRedirectContinueUrlAuthenticationFailureHandler(String defaultFailureUrl) {
+        setDefaultFailureUrl(defaultFailureUrl + "?error");
+    }
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        String continueUrl = getContinueUrl(request);
+
+        if (hasText(continueUrl)) {
+            removeContinueUrl(request);
+
+            getRedirectStrategy()
+                    .sendRedirect(request, response, buildContinueUrlWithError(continueUrl, exception));
+
+            return;
+        }
+
+        super.onAuthenticationFailure(request, response, exception);
+    }
+
+    private String buildContinueUrlWithError(String continueUrl, AuthenticationException exception) {
+        return fromHttpUrl(continueUrl)
+                .queryParam("error", extractErrorCode(exception))
+                .build()
+                .toString();
+    }
+
+    private String extractErrorCode(AuthenticationException exception) {
+        if (exception instanceof OAuth2AuthenticationException) {
+            return ((OAuth2AuthenticationException) exception)
+                    .getError()
+                    .getErrorCode();
+        }
+
+        return SERVER_ERROR;
+    }
+
+    private String getContinueUrl(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return null;
+        }
+
+        Object continueUrl = session.getAttribute(REDIRECT_URI_PARAMETER_NAME);
+
+        if (continueUrl == null) {
+            return null;
+        }
+
+        return (String) continueUrl;
+    }
+
+    private void removeContinueUrl(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return;
+        }
+
+        session.removeAttribute(REDIRECT_URI_PARAMETER_NAME);
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/Oauth2ClientRedirectContinueUrlAuthenticationSuccessHandler.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/Oauth2ClientRedirectContinueUrlAuthenticationSuccessHandler.java
@@ -1,0 +1,61 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+import static com.seeyouletter.api_member.auth.config.Oauth2ClientAuthorizationRequestSaveContinueUrlFilter.REDIRECT_URI_PARAMETER_NAME;
+import static org.springframework.util.StringUtils.hasText;
+
+public class Oauth2ClientRedirectContinueUrlAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        String continueUrl = getContinueUrl(request);
+
+        if (hasText(continueUrl)) {
+            removeContinueUrl(request);
+
+            clearAuthenticationAttributes(request);
+
+            getRedirectStrategy()
+                    .sendRedirect(request, response, continueUrl);
+
+            return;
+        }
+
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+
+    private String getContinueUrl(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return null;
+        }
+
+        Object continueUrl = session.getAttribute(REDIRECT_URI_PARAMETER_NAME);
+
+        if (continueUrl == null) {
+            return null;
+        }
+
+        return (String) continueUrl;
+    }
+
+    private void removeContinueUrl(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return;
+        }
+
+        session.removeAttribute(REDIRECT_URI_PARAMETER_NAME);
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
@@ -1,18 +1,23 @@
 package com.seeyouletter.api_member.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.seeyouletter.api_member.auth.config.RestLoginHttpConfigurer;
+import com.seeyouletter.api_member.auth.config.Oauth2ClientAuthorizationRequestSaveContinueUrlFilter;
 import com.seeyouletter.api_member.auth.config.RestAuthenticationProcessingFilter;
+import com.seeyouletter.api_member.auth.config.RestLoginHttpConfigurer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -21,14 +26,20 @@ import static java.util.Collections.singletonList;
 @RequiredArgsConstructor
 public class SecurityConfiguration {
 
+    private static final List<String> FIRST_PARTY_CLIENT_ORIGINS = asList(
+            "http://localhost:2462",
+            "http://127.0.0.1:2462",
+            "https://seeyouletter.kr",
+            "https://www.seeyouletter.kr"
+    );
+
     private final ObjectMapper objectMapper;
+
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
-
-
-        httpSecurity
-                .oauth2Login();
+        applyOauth2ClientSecurity(httpSecurity);
 
         httpSecurity
                 .apply(new RestLoginHttpConfigurer(objectMapper));
@@ -52,6 +63,21 @@ public class SecurityConfiguration {
         return httpSecurity.build();
     }
 
+    private void applyOauth2ClientSecurity(HttpSecurity http) throws Exception {
+        http
+                .oauth2Login()
+                .successHandler(new Oauth2ClientRedirectContinueUrlAuthenticationSuccessHandler())
+                .failureHandler(new Oauth2ClientRedirectContinueUrlAuthenticationFailureHandler())
+                .and()
+                .addFilterBefore(
+                        new Oauth2ClientAuthorizationRequestSaveContinueUrlFilter(
+                                clientRegistrationRepository,
+                                FIRST_PARTY_CLIENT_ORIGINS
+                        ),
+                        OAuth2AuthorizationRequestRedirectFilter.class
+                );
+    }
+
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
@@ -60,15 +86,7 @@ public class SecurityConfiguration {
         configuration.setAllowedMethods(singletonList("*"));
         configuration.setExposedHeaders(singletonList("*"));
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(
-                asList(
-                        "http://localhost:2462",
-                        "http://127.0.0.1:9600",
-                        "http://127.0.0.1:2462",
-                        "https://seeyouletter.kr",
-                        "https://www.seeyouletter.kr"
-                )
-        );
+        configuration.setAllowedOrigins(FIRST_PARTY_CLIENT_ORIGINS);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/SecurityConfiguration.java
@@ -17,25 +17,17 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
-
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfiguration {
 
-    private static final List<String> FIRST_PARTY_CLIENT_ORIGINS = asList(
-            "http://localhost:2462",
-            "http://127.0.0.1:2462",
-            "https://seeyouletter.kr",
-            "https://www.seeyouletter.kr"
-    );
-
     private final ObjectMapper objectMapper;
 
     private final ClientRegistrationRepository clientRegistrationRepository;
+
+    private final FirstPartyClientProperties firstPartyClientProperties;
 
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
@@ -72,7 +64,7 @@ public class SecurityConfiguration {
                 .addFilterBefore(
                         new Oauth2ClientAuthorizationRequestSaveContinueUrlFilter(
                                 clientRegistrationRepository,
-                                FIRST_PARTY_CLIENT_ORIGINS
+                                firstPartyClientProperties.getOrigins()
                         ),
                         OAuth2AuthorizationRequestRedirectFilter.class
                 );
@@ -86,7 +78,7 @@ public class SecurityConfiguration {
         configuration.setAllowedMethods(singletonList("*"));
         configuration.setExposedHeaders(singletonList("*"));
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(FIRST_PARTY_CLIENT_ORIGINS);
+        configuration.setAllowedOrigins(firstPartyClientProperties.getOrigins());
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 

--- a/api-member/src/main/resources/application-dev.yml
+++ b/api-member/src/main/resources/application-dev.yml
@@ -67,6 +67,15 @@ spring:
             userInfoUri: https://kapi.kakao.com/v2/user/me
             userNameAttribute: id
 
+first:
+  party:
+    client:
+      origins:
+        - http://localhost:2462,
+        - http://127.0.0.1:2462,
+        - https://seeyouletter.kr,
+        - https://www.seeyouletter.kr
+
 aws:
   s3:
     region: ap-northeast-2

--- a/api-member/src/main/resources/application-local.yml
+++ b/api-member/src/main/resources/application-local.yml
@@ -68,6 +68,11 @@ spring:
             userInfoUri: https://kapi.kakao.com/v2/user/me
             userNameAttribute: id
 
+first:
+  party:
+    client:
+      origins:
+        - http://localhost:${server.port}
 
 aws:
   endpoint: http://127.0.0.1:4566

--- a/api-member/src/test/resources/application-test.yml
+++ b/api-member/src/test/resources/application-test.yml
@@ -64,6 +64,12 @@ spring:
             userInfoUri: https://kapi.kakao.com/v2/user/me
             userNameAttribute: id
 
+first:
+  party:
+    client:
+      origins:
+        - http://localhost:8080
+
 aws:
   s3:
     region: test


### PR DESCRIPTION
## 💌 설명

인증 서버에서 제공하는 로그인 페이지가 아닌 씨유레터 로그인 페이지에서 Third Party(카카오, 네이버) 로그인으로 진입하는 경우 최종적으로 씨유레터 페이지로 이동해야합니다. 로그인 진입 페이지와 다른 페이지인 인증 서버로 리다이렉트를 하게 되면 유저는 좋지 못한 UX를 경험하게 됩니다.
네이버, 카카오 로그인 페이지로 이동하여 로그인 이후 씨유레터 유저로 회원가입 및 세션 생성 처리를 마친 후에 기본적으로 인증 서버의 루트 경로로 리다이렉트하며 리다이렉트 시킬 경로를 파라미터로 전달하면 해당 경로로 리다이렉트합니다. 리다이렉트 경로는 허용된 도메인의 경로(씨유레터 도메인)만 유효한 리다이렉트로 사용할 수 있습니다.

```
최종적으로 인증 서버의 루트 경로로 이동
/oauth2/authorization/naver

최종적으로 https://www.seeyouletter.kr/hello 경로로 이동
/oauth2/authorization/naver?continueUrl=https://www.seeyouletter.kr/hello
```

## 📎 관련 이슈

closed #54

## 💡 논의해볼 사항

@bulmandu 구현 내용에 대해서 자세히 봐주시고 더 좋은 방법이 있을지 함께 고민해주세요!

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
