### PR TITLE
test(api-member): Rest API 로그인 테스트 코드를 추가한다.

### DIFF
--- a/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
@@ -4,10 +4,7 @@ import com.seeyouletter.api_member.IntegrationTestContext;
 import com.seeyouletter.api_member.auth.value.LoginRequest;
 import com.seeyouletter.domain_member.entity.User;
 import com.seeyouletter.domain_member.repository.UserRepository;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,7 +17,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Nested
 @DisplayName("Rest API 로그인")
 class RestAuthenticationTest extends IntegrationTestContext {
 
@@ -98,6 +94,11 @@ class RestAuthenticationTest extends IntegrationTestContext {
                 .phone("01031157613")
                 .regDate(LocalDateTime.now())
                 .build();
+    }
+
+    @AfterAll
+    static void deleteUser(@Autowired UserRepository userRepository){
+        userRepository.deleteAllInBatch();
     }
 
 }

--- a/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
@@ -1,0 +1,103 @@
+package com.seeyouletter.api_member.e2e;
+
+import com.seeyouletter.api_member.IntegrationTestContext;
+import com.seeyouletter.api_member.auth.value.LoginRequest;
+import com.seeyouletter.domain_member.entity.User;
+import com.seeyouletter.domain_member.repository.UserRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.seeyouletter.domain_member.enums.GenderType.MALE;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Nested
+@DisplayName("Rest API 로그인")
+class RestAuthenticationTest extends IntegrationTestContext {
+
+    private static final String loginPath = "/login";
+    private static final String testUsername = "test@seeyouletter.kr";
+    private static final String testPassword = "password";
+    private static final String testFailUsername = "fail@seeyouletter.kr";
+    private static final String testFailPassword = "failPassword";
+
+    @BeforeAll
+    static void registerUser(@Autowired UserRepository userRepository,
+                             @Autowired PasswordEncoder passwordEncoder){
+        userRepository.save(createUser(passwordEncoder));
+    }
+
+    @Test
+    @DisplayName("success")
+    void successLogin() throws Exception {
+
+        LoginRequest loginRequest = new LoginRequest(testUsername, testPassword);
+
+        mockMvc
+                .perform(
+                        post(loginPath)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsBytes(loginRequest))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+
+    }
+
+    @Test
+    @DisplayName("fail by unregistered username")
+    void failLoginByUsername() throws Exception {
+
+        LoginRequest failPasswordLoginRequest = new LoginRequest(testFailUsername, testPassword);
+
+        mockMvc
+                .perform(
+                        post(loginPath)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsBytes(failPasswordLoginRequest))
+                )
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("fail by wrong password")
+    void failLoginByPassword() throws Exception {
+
+        LoginRequest failUsernameLoginRequest = new LoginRequest(testUsername, testFailPassword);
+
+        mockMvc
+                .perform(
+                        post(loginPath)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsBytes(failUsernameLoginRequest))
+                )
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+    static User createUser(PasswordEncoder passwordEncoder) {
+        return User
+                .builder()
+                .email(testUsername)
+                .password(passwordEncoder.encode(testPassword))
+                .name("테스트")
+                .birth(LocalDate.now())
+                .genderType(MALE)
+                .howJoin("테스트를 위한 계정입니다.")
+                .lastAccess(LocalDateTime.now())
+                .phone("01031157613")
+                .regDate(LocalDateTime.now())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 💌 설명

Rest API 로그인 e2e 테스트 코드를 아래의 3가지 케이스로 추가했습니다.
- 성공
- 등록되어 있지 않은 아이디
- 잘못된 패스워드

## 📎 관련 이슈

#53 

## 💡 논의해볼 사항


## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
