### PR TITLE
개발 환경 cors 허용 origin 목록의 오타를 수정한다.

### DIFF
--- a/api-member/src/main/resources/application-dev.yml
+++ b/api-member/src/main/resources/application-dev.yml
@@ -71,9 +71,9 @@ first:
   party:
     client:
       origins:
-        - http://localhost:2462,
-        - http://127.0.0.1:2462,
-        - https://seeyouletter.kr,
+        - http://localhost:2462
+        - http://127.0.0.1:2462
+        - https://seeyouletter.kr
         - https://www.seeyouletter.kr
 
 aws:


### PR DESCRIPTION
## 💌 설명

현재 `CORS`를 허용하는 설정 파일의 오리진 목록에 오타가 기입되어 의도한 대로 작동하지 않으며 허용되어야 하는 오리진에서 `CORS` 에러가 발생합니다. 
단순한 오타 기입으로 인한 버그이며 `CORS` 허용 오리진들의 끝에 기입된 ,(comma)를 제거합니다.

## 📎 관련 이슈
closed #61 

## 💡 논의해볼 사항

## 📝 참고자료

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
