### PR TITLE
docs(api-member): 로그인 API rest-docs 문서추가

### DIFF
--- a/api-member/src/docs/asciidoc/authentication-server.adoc
+++ b/api-member/src/docs/asciidoc/authentication-server.adoc
@@ -1,0 +1,39 @@
+= Seeyouletter Authentication Server REST API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 설명
+인가에 필요한 엑세스 토큰을 발급하기 위해서는 인증서버의 로그인성공 후 세션 획득이 필요합니다.
+
+NOTE: 2023-03-25 작성일 기준
+
+=== Error Response
+|===
+| Name | Required | Description
+
+| error | true | 에러 유형
+| error_description | false | 에러에 대한 정보
+| error_uri | false | 에러에 대한 졍보를 포함한 웹 페이지 URI
+|===
+
+[[login]]
+== Seeyouletter 로그인
+
+인가를 위한 토큰을 발급하기전 선행되어야하는 로그인 API 문서 입니다.
+
+=== HTTP request
+include::{snippets}/login/http-request.adoc[]
+
+=== Request body
+include::{snippets}/login/request-body.adoc[]
+
+=== HTTP response
+include::{snippets}/login/http-response.adoc[]

--- a/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
@@ -4,16 +4,23 @@ import com.seeyouletter.api_member.IntegrationTestContext;
 import com.seeyouletter.api_member.auth.value.LoginRequest;
 import com.seeyouletter.domain_member.entity.User;
 import com.seeyouletter.domain_member.repository.UserRepository;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.seeyouletter.domain_member.enums.GenderType.MALE;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -45,7 +52,18 @@ class RestAuthenticationTest extends IntegrationTestContext {
                                 .content(objectMapper.writeValueAsBytes(loginRequest))
                 )
                 .andExpect(status().isOk())
-                .andDo(print());
+                .andDo(print())
+                .andDo(
+                        document(
+                                "login",
+                                REQUEST_PREPROCESSOR,
+                                RESPONSE_PREPROCESSOR,
+                                requestFields(
+                                        fieldWithPath("username").type(JsonFieldType.STRING).description("아이디"),
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("패스워드")
+                                )
+                        )
+                );
 
     }
 


### PR DESCRIPTION
## 💌 설명

<!-- 해당 PR에 대하여 간단한 설명이 필요해요! 🙆🏻 -->
로그인 API 테스트코드에 rest docs 문서를 추가하였습니다.

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->
#57 

## 💡 논의해볼 사항
로그인 성공 후 세션여부를 파악하여 검증하려했지만 테스트 환경에서는 세션을 가져올 수 없는 것 같았습니다.
그런데 갑자기 status 200을 받았다면 세션생성 여부를 검증할 필요가 없나? 하는 생각도 들긴합니다.
검증이 불가능 할것 같지는 않은데 방법을 못찾았네요 혹시 방법을 아시면 알려주세용

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
