### PR TITLE
 oauth2 authorization server endpoint의 error response에 대한 설명을 문서에 추가한다.

### DIFF
--- a/api-member/src/docs/asciidoc/oauth2-authorization-server.adoc
+++ b/api-member/src/docs/asciidoc/oauth2-authorization-server.adoc
@@ -1,4 +1,4 @@
-= Oauth2 Authorization Server REST API Document
+= Oauth2 Authorization Server API
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
@@ -16,6 +16,18 @@ seeyouletter 서비스를 구성하는 웹 애플리케이션들의 인증 및 �
 NOTE: 2023-01-25 작성일 기준으로 `public-client` 인 SPA에서만 서비스를 지원하는 시점에서 작성된 문서입니다.
 
 === Error Response
+
+[source,http,options="nowrap"]
+----
+HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+
+{
+  "error_description" : "OAuth 2.0 Parameter: grant_type",
+  "error" : "unsupported_grant_type",
+  "error_uri" : "https://datatracker.ietf.org/doc/html/rfc6749#section-5.2"
+}
+----
 |===
 | Name | Required | Description
 
@@ -47,16 +59,50 @@ NOTE: 2023-01-25 작성일 기준으로 `public-client` 인 SPA에서만 서비�
 `OIDC scope` 에 대해서는 link:https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse[해당 문서]를 참고해주세요.
 
 === HTTP request
-include::{snippets}/authorization/http-request.adoc[]
+include::{snippets}/authorization/authorization/http-request.adoc[]
 
 === Request parameters
-include::{snippets}/authorization/request-parameters.adoc[]
+include::{snippets}/authorization/authorization/request-parameters.adoc[]
 
 === HTTP response
-include::{snippets}/authorization/http-response.adoc[]
+include::{snippets}/authorization/authorization/http-response.adoc[]
 
 === Request headers
-include::{snippets}/authorization/response-headers.adoc[]
+include::{snippets}/authorization/authorization/response-headers.adoc[]
+
+=== Error Response
+
+인가 요청에서 발생하는 에러에 대한 처리는 유효하지 않은 파라미터에 따라 다릅니다. 인가 요청시에 전달한 `client_id`, `redirect_uri` 파라미터가 유효하지 않아도 리다이렉트를 하게되면 공격자의 페이지로 리다이렉트를 유도할 수 있게되므로 리다이렉트를 하지 않고 인증 서버에서 에러 페이지를 응답합니다. 자세한 내용은 link:https://www.rfc-editor.org/rfc/rfc6749#section-10.15[해당 문서]를 참고해주세요.
+
+==== 입력되지 않거나 유효하지 않은 client_id 파라미터로 요청한 경우
+[source,http,options="nowrap"]
+----
+HTTP/1.1 400 Bad Request
+
+(400 HTML 에러 페이지)
+----
+
+==== 입력되지 않거나 유효하지 않은 redirect_uri 파라미터로 요청한 경우
+[source,http,options="nowrap"]
+----
+HTTP/1.1 400 Bad Request
+
+(400 HTML 에러 페이지)
+----
+
+==== 입력되지 않거나 유효하지 않은 response_type 파라미터로 요청한 경우
+[source,http,options="nowrap"]
+----
+HTTP/1.1 400 Bad Request
+
+(400 HTML 에러 페이지)
+----
+
+==== 유효하지 않은 scope 파라미터로 요청한 경우
+include::{snippets}/authorization/fail-authorization-when-invalid-scope/http-response.adoc[]
+
+==== 입력되지 않거나 유효하지 않은 code_challenge 파라미터로 요청한 경우
+include::{snippets}/authorization/fail-authorization-when-invalid-or-empty-code-challenge-method/http-response.adoc[]
 
 [[token]]
 == 토큰 발급
@@ -66,22 +112,46 @@ include::{snippets}/authorization/response-headers.adoc[]
 인가 요청의 응답에서 리다이렉트된 경로에 포함된 접근 토큰인 `code` 로 엑세스 토큰 발급을 요청합니다.
 
 === HTTP request
-include::{snippets}/token/http-request.adoc[]
+include::{snippets}/token/token/http-request.adoc[]
 
 === Request headers
-include::{snippets}/token/request-headers.adoc[]
+include::{snippets}/token/token/request-headers.adoc[]
 
 === Request parameters
-include::{snippets}/token/request-parameters.adoc[]
+include::{snippets}/token/token/request-parameters.adoc[]
 
 === HTTP response
-include::{snippets}/token/http-response.adoc[]
+include::{snippets}/token/token/http-response.adoc[]
 
 === Request headers
-include::{snippets}/token/response-headers.adoc[]
+include::{snippets}/token/token/response-headers.adoc[]
 
 === Response fields
-include::{snippets}/token/response-fields.adoc[]
+include::{snippets}/token/token/response-fields.adoc[]
+
+=== Error Response
+
+==== 입력되지 않은 client_id 파라미터로 요청한 경우
+include::{snippets}/token/fail-token-when-empty-client-id/http-response.adoc[]
+
+==== 유효하지 않은 client_id 파라미터로 요청한 경우
+include::{snippets}/token/fail-token-when-invalid-client-id/http-response.adoc[]
+
+==== 입력되지 않거나 입력되지 않거나 유효하지 않은 redirect_uri 파라미터로 요청한 경우
+include::{snippets}/token/fail-token-when-invalid-or-empty-redirect-uri/http-response.adoc[]
+
+==== 입력되지 않거나 입력되지 않거나 유효하지 않은 code_verifier 파라미터로 요청한 경우
+include::{snippets}/token/fail-token-when-invalid-or-empty-code-verifier/http-response.adoc[]
+
+==== 입력되지 않은 authorization_code 파라미터로 요청한 경우
+include::{snippets}/token/fail-token-when-empty-authorization-code/http-response.adoc[]
+
+==== 유효하지 않은 authorization_code 파라미터로 요청한 경우
+include::{snippets}/token/fail-token-when-invalid-authorization-code/http-response.adoc[]
+
+==== 입력되지 않거나 입력되지 않거나 유효하지 않은 grant_type 파라미터로 요청한 경우
+include::{snippets}/token/fail-token-when-invalid-or-empty-grant-type/http-response.adoc[]
+
 
 [[introspect]]
 == 토큰 정보
@@ -89,41 +159,81 @@ include::{snippets}/token/response-fields.adoc[]
 인증 서버에서 발급한 엑세스 토큰에 대한 정보를 조회합니다.
 
 === HTTP request
-include::{snippets}/introspect/http-request.adoc[]
+include::{snippets}/introspect/introspect/http-request.adoc[]
 
 === Request headers
-include::{snippets}/introspect/request-headers.adoc[]
+include::{snippets}/introspect/introspect/request-headers.adoc[]
 
 === Request parameters
-include::{snippets}/introspect/request-parameters.adoc[]
+include::{snippets}/introspect/introspect/request-parameters.adoc[]
 
 === HTTP response
-include::{snippets}/introspect/http-response.adoc[]
+include::{snippets}/introspect/introspect/http-response.adoc[]
 
 === Request headers
-include::{snippets}/introspect/response-headers.adoc[]
+include::{snippets}/introspect/introspect/response-headers.adoc[]
 
 === Response fields
-include::{snippets}/introspect/response-fields.adoc[]
+include::{snippets}/introspect/introspect/response-fields.adoc[]
+
+=== Error Response
+
+==== 입력되지 않은 client_id 파라미터로 요청한 경우
+include::{snippets}/introspect/fail-introspect-when-empty-client-id/http-response.adoc[]
+
+==== 유효하지 않은 client_id 파라미터로 요청한 경우
+include::{snippets}/introspect/fail-introspect-when-invalid-client-id/http-response.adoc[]
+
+==== 입력되지 않거나 유효하지 않은 code-verifier 파라미터로 요청한 경우
+include::{snippets}/introspect/fail-introspect-when-invalid-or-empty-code-verifier/http-response.adoc[]
+
+==== 입력되지 않거나 유효하지 않은 grant_type 파라미터로 요청한 경우
+include::{snippets}/introspect/fail-introspect-when-invalid-or-empty-grant-type/http-response.adoc[]
+
+==== 입력되지 않은 access_token 파라미터로 요청한 경우
+include::{snippets}/introspect/fail-introspect-when-empty-access-token/http-response.adoc[]
+
+==== 유효하지 않은 access_token 파라미터로 요청한 경우
+include::{snippets}/introspect/fail-introspect-when-invalid-access-token/http-response.adoc[]
+
 
 [[revoke]]
 == 토큰 무효화
 
 인증 서버에서 발급한 엑세스 토큰을 무효화합니다.
 
+유효하지 않은 토큰을 무효화 요청하더라도 에러가 발생하지는 않습니다.
+
 NOTE: JWT 토큰은 `self-contained` 특성을 가지기 때문에 인증 서버에서 무효화하더라도 서명이 일치하고 유효기간이 지나지 않았다면 리소스 서버에서는 유효한 토큰으로 인식할 수 있습니다.
 
 === HTTP request
-include::{snippets}/revoke/http-request.adoc[]
+include::{snippets}/revoke/revoke/http-request.adoc[]
 
 === Request headers
-include::{snippets}/revoke/request-headers.adoc[]
+include::{snippets}/revoke/revoke/request-headers.adoc[]
 
 === Request parameters
-include::{snippets}/revoke/request-parameters.adoc[]
+include::{snippets}/revoke/revoke/request-parameters.adoc[]
 
 === HTTP response
-include::{snippets}/revoke/http-response.adoc[]
+include::{snippets}/revoke/revoke/http-response.adoc[]
+
+=== Error Response
+
+==== 입력되지 않은 client_id 파라미터로 요청한 경우
+include::{snippets}/revoke/fail-revoke-when-empty-client-id/http-response.adoc[]
+
+==== 유효하지 않은 client_id 파라미터로 요청한 경우
+include::{snippets}/revoke/fail-revoke-when-invalid-client-id/http-response.adoc[]
+
+==== 입력되지 않거나 유효하지 않은 code_verifier 파라미터로 요청한 경우
+include::{snippets}/revoke/fail-revoke-when-invalid-or-empty-code-verifier/http-response.adoc[]
+
+==== 입력되지 않거나 유효하지 않은 grant_type 파라미터로 요청한 경우
+include::{snippets}/revoke/fail-revoke-when-invalid-or-empty-grant-type/http-response.adoc[]
+
+==== 입력되지 않은 access_token 파라미터로 요청한 경우
+include::{snippets}/revoke/fail-revoke-when-empty-access-token/http-response.adoc[]
 
 [[userinfo]]
 == 유저 정보
@@ -135,16 +245,21 @@ include::{snippets}/revoke/http-response.adoc[]
 NOTE: 유저 정보에 대한 명세를 구체화함에 따라 응답 필드는 지속적으로 추가될 수 있습니다.
 
 === HTTP request
-include::{snippets}/userinfo/http-request.adoc[]
+include::{snippets}/userinfo/userinfo/http-request.adoc[]
 
 === Request headers
-include::{snippets}/userinfo/request-headers.adoc[]
+include::{snippets}/userinfo/userinfo/request-headers.adoc[]
 
 === HTTP response
-include::{snippets}/userinfo/http-response.adoc[]
+include::{snippets}/userinfo/userinfo/http-response.adoc[]
 
 === Request headers
-include::{snippets}/userinfo/response-headers.adoc[]
+include::{snippets}/userinfo/userinfo/response-headers.adoc[]
 
 === Response fields
-include::{snippets}/userinfo/response-fields.adoc[]
+include::{snippets}/userinfo/userinfo/response-fields.adoc[]
+
+=== Error Response
+
+==== 입력되지 않거나 유효하지 않은 access_token 파라미터로 요청한 경우
+include::{snippets}/userinfo/fail-userinfo-when-invalid-or-empty-access-token/http-response.adoc[]

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/RedisOauth2AuthorizationService.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/RedisOauth2AuthorizationService.java
@@ -41,11 +41,13 @@ import static org.springframework.security.jackson2.SecurityJackson2Modules.getM
 import static org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE;
 import static org.springframework.security.oauth2.core.AuthorizationGrantType.CLIENT_CREDENTIALS;
 import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType.BEARER;
+import static org.springframework.security.oauth2.core.OAuth2ErrorCodes.INVALID_REQUEST;
 import static org.springframework.security.oauth2.core.OAuth2ErrorCodes.SERVER_ERROR;
 import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.CODE;
 import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.STATE;
 import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.ACCESS_TOKEN;
 import static org.springframework.security.oauth2.server.authorization.OAuth2TokenType.REFRESH_TOKEN;
+import static org.springframework.util.StringUtils.hasText;
 
 public final class RedisOauth2AuthorizationService implements OAuth2AuthorizationService {
 
@@ -134,9 +136,11 @@ public final class RedisOauth2AuthorizationService implements OAuth2Authorizatio
 
     @Override
     public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {
-        try {
-            Assert.hasText(token, "token cannot be empty");
+        if (!hasText(token)) {
+            throw new OAuth2AuthenticationException(INVALID_REQUEST);
+        }
 
+        try {
             String authorizationId = findAuthorizationIdByTokenAndTokenType(token, tokenType);
 
             if (authorizationId == null) {

--- a/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/IntegrationTestContext.java
@@ -1,14 +1,14 @@
 package com.seeyouletter.api_member;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seeyouletter.api_member.config.RestDocsConfiguration;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
-import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -16,14 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import static org.springframework.http.HttpHeaders.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-
 @Disabled
 @Transactional
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @SpringBootTest
+@ContextConfiguration(classes = RestDocsConfiguration.class)
 @ActiveProfiles(value = "test")
 public abstract class IntegrationTestContext {
 
@@ -39,14 +37,8 @@ public abstract class IntegrationTestContext {
     @Autowired
     protected ObjectMapper objectMapper;
 
-    public static final OperationRequestPreprocessor REQUEST_PREPROCESSOR;
-
-    public static final OperationResponsePreprocessor RESPONSE_PREPROCESSOR;
-
     static {
         REDIS_CONTAINER = createRedisContainer();
-        REQUEST_PREPROCESSOR = createRequestPreprocessor();
-        RESPONSE_PREPROCESSOR = createResponsePreprocessor();
         REDIS_CONTAINER.start();
     }
 
@@ -59,35 +51,6 @@ public abstract class IntegrationTestContext {
         return DockerImageName
                 .parse(REDIS_IMAGE)
                 .withTag(REDIS_VERSION);
-    }
-
-    private static OperationRequestPreprocessor createRequestPreprocessor() {
-        return preprocessRequest(
-                removeHeaders(
-                        "X-Forwarded-Host",
-                        "X-Forwarded-Proto",
-                        CONTENT_LENGTH
-                ),
-                modifyParameters()
-                        .remove("_csrf"),
-                prettyPrint()
-        );
-    }
-
-    private static OperationResponsePreprocessor createResponsePreprocessor() {
-        return preprocessResponse(
-                prettyPrint(),
-                removeHeaders(
-                        "X-Content-Type-Options",
-                        "X-XSS-Protection",
-                        "X-Frame-Options",
-                        "Pragma",
-                        VARY,
-                        CACHE_CONTROL,
-                        EXPIRES,
-                        CONTENT_LENGTH
-                )
-        );
     }
 
     @DynamicPropertySource

--- a/api-member/src/test/java/com/seeyouletter/api_member/config/RestDocsConfiguration.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/config/RestDocsConfiguration.java
@@ -1,0 +1,59 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.snippet.Snippet;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+
+    @Bean
+    public CharacterEncodingFilter characterEncodingFilter() {
+        return new CharacterEncodingFilter("UTF-8", true);
+    }
+
+    @Bean
+    public RestDocsMockMvcConfigurationCustomizer restDocsMockMvcConfigurationCustomizer() {
+        return configurer -> configurer
+                .operationPreprocessors()
+                .withRequestDefaults(
+                        prettyPrint(),
+                        removeHeaders(
+                                "X-Forwarded-Host",
+                                "X-Forwarded-Proto",
+                                CONTENT_LENGTH
+                        ),
+                        modifyUris()
+                                .scheme("https")
+                                .host("dev-member.seeyouletter.kr")
+                                .removePort(),
+                        modifyParameters()
+                                .remove("_csrf")
+                )
+                .withResponseDefaults(
+                        prettyPrint(),
+                        removeHeaders(
+                                "X-Content-Type-Options",
+                                "X-XSS-Protection",
+                                "X-Frame-Options",
+                                "Pragma",
+                                VARY,
+                                CACHE_CONTROL,
+                                EXPIRES,
+                                CONTENT_LENGTH
+                        )
+                );
+    }
+
+    public static RestDocumentationResultHandler defaultDocument(Snippet... snippets) {
+        return document("{class-name}/{method-name}", snippets);
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
 
     dependencies {
         annotationProcessor 'org.projectlombok:lombok'
-        implementation 'org.projectlombok:lombok'
+        compileOnly 'org.projectlombok:lombok'
         testImplementation 'org.mockito:mockito-inline'
     }
 


### PR DESCRIPTION
## 💌 설명

 oauth2 authorization server endpoint의 error response에 대한 설명을 문서에 추가합니다.

## 📎 관련 이슈

close #55 

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
