### PR TITLE
이메일 중복 불가능한 정책에 맞게 User, Oauth2User 엔티티의 스키마를 수정한다.

### DIFF
--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/value/KakaoAttributes.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/value/KakaoAttributes.java
@@ -9,12 +9,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class KakaoAttributes implements OauthAttributes{
+public class KakaoAttributes implements OauthAttributes {
 
     private Long id;
 
@@ -31,24 +30,21 @@ public class KakaoAttributes implements OauthAttributes{
                 .email((String) kakaoAccount.get("email"))
                 .profileImage(properties.get("profile_image"))
                 .genderType(convertGender((String) kakaoAccount.get("gender")))
-                .regDate(LocalDateTime.now())
-                .lastAccess(LocalDateTime.now())
                 .build();
 
         return new OauthUser(
-            null,
-            Long.toString(id),
-            OauthType.KAKAO,
-            user
+                Long.toString(id),
+                OauthType.KAKAO,
+                user
         );
     }
 
-    private GenderType convertGender(String gender){
-        if("male".equals(gender)){
+    private GenderType convertGender(String gender) {
+        if ("male".equals(gender)) {
             return GenderType.MALE;
         }
 
-        if("female".equals(gender)){
+        if ("female".equals(gender)) {
             return GenderType.FEMALE;
         }
 

--- a/api-member/src/main/java/com/seeyouletter/api_member/auth/value/NaverAttributes.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/auth/value/NaverAttributes.java
@@ -8,12 +8,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NaverAttributes implements OauthAttributes{
+public class NaverAttributes implements OauthAttributes {
 
     private String resultCode;
 
@@ -28,12 +27,9 @@ public class NaverAttributes implements OauthAttributes{
                 .email(response.get("email"))
                 .phone(response.get("mobile").replace("-", ""))
                 .genderType(GenderType.find(response.get("gender")))
-                .regDate(LocalDateTime.now())
-                .lastAccess(LocalDateTime.now())
                 .build();
 
         return new OauthUser(
-                null,
                 response.get("id"),
                 OauthType.NAVER,
                 user

--- a/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/e2e/RestAuthenticationTest.java
@@ -84,15 +84,15 @@ class RestAuthenticationTest extends IntegrationTestContext {
     static User createUser(PasswordEncoder passwordEncoder) {
         return User
                 .builder()
+                .name("테스트")
                 .email(testUsername)
                 .password(passwordEncoder.encode(testPassword))
-                .name("테스트")
-                .birth(LocalDate.now())
-                .genderType(MALE)
+                .profileImage("https://www.test.com/image/me")
                 .howJoin("테스트를 위한 계정입니다.")
-                .lastAccess(LocalDateTime.now())
                 .phone("01031157613")
-                .regDate(LocalDateTime.now())
+                .genderType(MALE)
+                .birth(LocalDate.now())
+                .howJoin("테스트")
                 .build();
     }
 

--- a/domain-member/src/main/java/com/seeyouletter/domain_member/config/DomainMemberAutoConfiguration.java
+++ b/domain-member/src/main/java/com/seeyouletter/domain_member/config/DomainMemberAutoConfiguration.java
@@ -8,16 +8,17 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import javax.persistence.EntityManager;
 
 @AutoConfiguration
-@RequiredArgsConstructor
 public class DomainMemberAutoConfiguration {
 
     @Configuration
     @EntityScan(basePackageClasses = {User.class})
+    @EnableJpaAuditing
     @EnableJpaRepositories(basePackageClasses = {UserRepository.class})
     @RequiredArgsConstructor
     public static class JpaConfiguration {

--- a/domain-member/src/main/java/com/seeyouletter/domain_member/entity/OauthUser.java
+++ b/domain-member/src/main/java/com/seeyouletter/domain_member/entity/OauthUser.java
@@ -2,34 +2,42 @@ package com.seeyouletter.domain_member.entity;
 
 import com.seeyouletter.domain_member.enums.OauthType;
 import com.seeyouletter.domain_member.enums.converter.OauthTypeConverter;
-import com.sun.istack.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
 @Getter
 @Entity
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "oauth_user")
+@NoArgsConstructor(access = PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class OauthUser {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
     private Long id;
 
-    @Column(unique = true)
+    @Column(name = "oauth_id", nullable = false, unique = true)
     private String oauthId;
 
-    @NotNull
-    @Column(nullable = false)
     @Convert(converter = OauthTypeConverter.class)
+    @Column(name = "provider", nullable = false)
     private OauthType provider;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_id")
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public OauthUser(String oauthId, OauthType provider, User user) {
+        this.oauthId = oauthId;
+        this.provider = provider;
+        this.user = user;
+    }
 
 }

--- a/domain-member/src/main/java/com/seeyouletter/domain_member/entity/User.java
+++ b/domain-member/src/main/java/com/seeyouletter/domain_member/entity/User.java
@@ -2,53 +2,75 @@ package com.seeyouletter.domain_member.entity;
 
 import com.seeyouletter.domain_member.enums.GenderType;
 import com.seeyouletter.domain_member.enums.converter.GenderTypeConverter;
-import com.sun.istack.NotNull;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Entity
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 @Table(name = "users")
+@NoArgsConstructor(access = PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
     private Long id;
 
-    @NotNull
-    @Column(length = 50, nullable = false)
+    @Column(name = "name", length = 50, nullable = false)
     private String name;
 
-    @NotNull
-    @Column(length = 50, nullable = false)
+    @Column(name = "email", length = 50, nullable = false, unique = true)
     private String email;
 
+    @Column(name = "profile_image")
     private String profileImage;
 
-    @Column(length = 100)
+    @Column(name = "password", length = 100)
     private String password;
 
-    @Column(length = 15)
+    @Column(name = "phone", length = 15)
     private String phone;
 
-    @NotNull
-    @Column(nullable = false)
     @Convert(converter = GenderTypeConverter.class)
+    @Column(name = "gender_type", nullable = false)
     private GenderType genderType;
 
+    @Column(name = "birth")
     private LocalDate birth;
 
-    @Column(length = 200)
+    @Column(name = "how_join", length = 200)
     private String howJoin;
 
+    @CreatedDate
+    @Column(name = "reg_date", updatable = false)
     private LocalDateTime regDate;
 
+    @CreatedDate
+    @Column(name = "last_access")
     private LocalDateTime lastAccess;
+
+    @Builder
+    private User(String name, String email, String profileImage, String password, String phone, GenderType genderType,
+                 LocalDate birth, String howJoin) {
+        this.name = name;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.password = password;
+        this.phone = phone;
+        this.genderType = genderType;
+        this.birth = birth;
+        this.howJoin = howJoin;
+    }
 
 }

--- a/domain-member/src/test/java/com/seeyouletter/domain_member/TestConfiguration.java
+++ b/domain-member/src/test/java/com/seeyouletter/domain_member/TestConfiguration.java
@@ -1,7 +1,10 @@
 package com.seeyouletter.domain_member;
 
+import com.seeyouletter.domain_member.config.DomainMemberAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
+@Import(value = DomainMemberAutoConfiguration.class)
 @SpringBootApplication
 public class TestConfiguration {
 }

--- a/domain-member/src/test/java/com/seeyouletter/domain_member/entity/UserTest.java
+++ b/domain-member/src/test/java/com/seeyouletter/domain_member/entity/UserTest.java
@@ -4,7 +4,6 @@ import com.seeyouletter.domain_member.enums.GenderType;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,25 +15,36 @@ class UserTest {
         // given
         String name = "신영진";
         String email = "dev.sinbom@gmail.com";
+        String password = "1234!@#$";
+        String profileImage = "https://www.test.com/image/me";
         String phone = "01011111111";
         GenderType genderType = GenderType.MALE;
         LocalDate birth = LocalDate.of(1996, 9, 17);
+        String howJoin = "테스트";
 
         // when
         User user = User.builder()
                 .name(name)
                 .email(email)
+                .password(password)
+                .profileImage(profileImage)
                 .phone(phone)
                 .genderType(genderType)
                 .birth(birth)
-                .regDate(LocalDateTime.now())
+                .howJoin(howJoin)
                 .build();
 
         // then
+        assertThat(user.getName()).isEqualTo(name);
         assertThat(user.getEmail()).isEqualTo(email);
+        assertThat(user.getPassword()).isEqualTo(password);
+        assertThat(user.getProfileImage()).isEqualTo(profileImage);
         assertThat(user.getPhone()).isEqualTo(phone);
         assertThat(user.getGenderType()).isEqualTo(genderType);
         assertThat(user.getBirth()).isEqualTo(birth);
+        assertThat(user.getHowJoin()).isEqualTo(howJoin);
+        assertThat(user.getRegDate()).isNull();
+        assertThat(user.getLastAccess()).isNull();
     }
 
 }

--- a/domain-member/src/test/java/com/seeyouletter/domain_member/repository/UserRepositoryTest.java
+++ b/domain-member/src/test/java/com/seeyouletter/domain_member/repository/UserRepositoryTest.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,17 +19,22 @@ class UserRepositoryTest {
     User createUser() {
         String name = "신영진";
         String email = "dev.sinbom@gmail.com";
+        String password = "1234!@#$";
+        String profileImage = "https://www.test.com/image/me";
         String phone = "01011111111";
         GenderType genderType = GenderType.MALE;
         LocalDate birth = LocalDate.of(1996, 9, 17);
+        String howJoin = "테스트";
 
         return User.builder()
                 .name(name)
                 .email(email)
+                .password(password)
+                .profileImage(profileImage)
                 .phone(phone)
                 .genderType(genderType)
                 .birth(birth)
-                .regDate(LocalDateTime.now())
+                .howJoin(howJoin)
                 .build();
     }
 
@@ -43,11 +47,17 @@ class UserRepositoryTest {
         User savedUser = userRepository.save(user);
 
         // then
+        assertThat(savedUser.getName()).isEqualTo(user.getName());
         assertThat(savedUser.getEmail()).isEqualTo(user.getEmail());
+        assertThat(savedUser.getPassword()).isEqualTo(user.getPassword());
+        assertThat(savedUser.getProfileImage()).isEqualTo(user.getProfileImage());
         assertThat(savedUser.getPhone()).isEqualTo(user.getPhone());
         assertThat(savedUser.getGenderType()).isEqualTo(user.getGenderType());
         assertThat(savedUser.getBirth()).isEqualTo(user.getBirth());
+        assertThat(savedUser.getHowJoin()).isEqualTo(user.getHowJoin());
         assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser.getRegDate()).isNotNull();
+        assertThat(savedUser.getLastAccess()).isNotNull();
     }
 
     @Test
@@ -56,10 +66,21 @@ class UserRepositoryTest {
         User savedUser = userRepository.save(createUser());
 
         // when
-        User foundUser = userRepository.findById(savedUser.getId()).get();
+        User foundUser = userRepository.findById(savedUser.getId())
+                .orElseThrow();
 
         // then
-        assertThat(savedUser.getEmail()).isEqualTo(foundUser.getEmail());
+        assertThat(foundUser.getName()).isEqualTo(savedUser.getName());
+        assertThat(foundUser.getEmail()).isEqualTo(savedUser.getEmail());
+        assertThat(foundUser.getPassword()).isEqualTo(savedUser.getPassword());
+        assertThat(foundUser.getProfileImage()).isEqualTo(savedUser.getProfileImage());
+        assertThat(foundUser.getPhone()).isEqualTo(savedUser.getPhone());
+        assertThat(foundUser.getGenderType()).isEqualTo(savedUser.getGenderType());
+        assertThat(foundUser.getBirth()).isEqualTo(savedUser.getBirth());
+        assertThat(foundUser.getHowJoin()).isEqualTo(savedUser.getHowJoin());
+        assertThat(foundUser.getId()).isEqualTo(savedUser.getId());
+        assertThat(foundUser.getRegDate()).isEqualTo(savedUser.getRegDate());
+        assertThat(foundUser.getLastAccess()).isEqualTo(savedUser.getLastAccess());
     }
 
 }


### PR DESCRIPTION
## 💌 설명

User 엔티티에 아래와 같은 내용을 수정했습니다.
- 정책상 중복이 될 수 없는 email 필드에 unique 제약조건 적용
- Builder 패턴에서 사용하는 생성자에서 @Id 애노테이션이 적용된 필드 제외
- @Column 애노테이션으로 명시적인 컬럼명 지정
- 영속화하는 시점에 생성하는 날짜 데이터에 @CreateDate Auditing 적용
- 의도와 다르게 잘못 사용된 것으로 보이는 애노테이션(com.sun.istack.NotNull) 사용 제거

Oauth2User 엔티티에 아래와 같은 내용을 수정했습니다.
- 생성자에서 @Id 애노테이션이 적용된 필드 제외
- @Column 애노테이션으로 명시적인 컬럼명 지정
- 필수 존재하는 User 엔티티 연관관계 매핑에 optioanl = false 적용
- 의도와 다르게 잘못 사용된 것으로 보이는 애노테이션(com.sun.istack.NotNull) 사용 제거

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
