### PR TITLE
에러 응답을 생성하는 전역 에러 핸들러 추가

### DIFF
--- a/api-member/build.gradle
+++ b/api-member/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation project(':domain-member')
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-redis'
     implementation 'org.springframework.security:spring-security-oauth2-authorization-server:0.4.0'

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/CustomErrorAttributes.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/CustomErrorAttributes.java
@@ -1,0 +1,206 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static javax.servlet.RequestDispatcher.*;
+import static org.springframework.boot.web.error.ErrorAttributeOptions.Include.*;
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+import static org.springframework.util.ObjectUtils.isEmpty;
+import static org.springframework.util.StringUtils.hasLength;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+@Order(HIGHEST_PRECEDENCE)
+public class CustomErrorAttributes implements ErrorAttributes, HandlerExceptionResolver, Ordered {
+
+    private static final String ERROR_INTERNAL_ATTRIBUTE = CustomErrorAttributes.class.getName() + ".ERROR";
+
+    @Override
+    public int getOrder() {
+        return HIGHEST_PRECEDENCE;
+    }
+
+    @Override
+    public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler,
+                                         Exception exception) {
+        storeErrorAttributes(request, exception);
+
+        return null;
+    }
+
+    private void storeErrorAttributes(HttpServletRequest request, Exception exception) {
+        request.setAttribute(ERROR_INTERNAL_ATTRIBUTE, exception);
+    }
+
+    @Override
+    public Map<String, Object> getErrorAttributes(WebRequest webRequest, ErrorAttributeOptions options) {
+        Map<String, Object> errorAttributes = getErrorAttributes(webRequest, options.isIncluded(STACK_TRACE));
+
+        if (!options.isIncluded(EXCEPTION)) {
+            errorAttributes.remove("exception");
+        }
+
+        if (!options.isIncluded(STACK_TRACE)) {
+            errorAttributes.remove("trace");
+        }
+
+        if (!options.isIncluded(MESSAGE) && errorAttributes.get("message") != null) {
+            errorAttributes.remove("message");
+        }
+
+        if (!options.isIncluded(BINDING_ERRORS)) {
+            errorAttributes.remove("errors");
+
+        }
+        return errorAttributes;
+    }
+
+    private Map<String, Object> getErrorAttributes(WebRequest webRequest, boolean includeStackTrace) {
+        Map<String, Object> errorAttributes = new LinkedHashMap<>();
+
+        errorAttributes.put("timestamp", LocalDateTime.now());
+        addStatus(errorAttributes, webRequest);
+        addErrorDetails(errorAttributes, webRequest, includeStackTrace);
+        addPath(errorAttributes, webRequest);
+
+        return errorAttributes;
+    }
+
+    private void addStatus(Map<String, Object> errorAttributes, RequestAttributes requestAttributes) {
+        Integer status = getAttribute(requestAttributes, ERROR_STATUS_CODE);
+
+        if (status == null) {
+            errorAttributes.put("status", 999);
+            errorAttributes.put("error", "None");
+
+            return;
+        }
+
+        errorAttributes.put("status", status);
+
+        try {
+            errorAttributes.put("error", HttpStatus.valueOf(status).getReasonPhrase());
+        } catch (Exception ex) {
+            errorAttributes.put("error", "Http Status " + status);
+        }
+    }
+
+    private void addErrorDetails(Map<String, Object> errorAttributes, WebRequest webRequest, boolean includeStackTrace) {
+        Throwable error = getError(webRequest);
+
+        if (error != null) {
+            while (error instanceof ServletException && error.getCause() != null) {
+                error = error.getCause();
+            }
+
+            errorAttributes.put("exception", error.getClass().getName());
+
+            if (includeStackTrace) {
+                addStackTrace(errorAttributes, error);
+            }
+        }
+
+        addErrorMessage(errorAttributes, webRequest, error);
+    }
+
+    private void addErrorMessage(Map<String, Object> errorAttributes, WebRequest webRequest, Throwable error) {
+        BindingResult result = extractBindingResult(error);
+
+        if (result == null) {
+            addExceptionErrorMessage(errorAttributes, webRequest, error);
+        } else {
+            addBindingResultErrorMessage(errorAttributes, result);
+        }
+    }
+
+    private void addExceptionErrorMessage(Map<String, Object> errorAttributes, WebRequest webRequest, Throwable error) {
+        errorAttributes.put("message", getMessage(webRequest, error));
+    }
+
+    protected String getMessage(WebRequest webRequest, Throwable error) {
+        Object message = getAttribute(webRequest, ERROR_MESSAGE);
+
+        if (!isEmpty(message)) {
+            return message.toString();
+        }
+
+        if (error != null && hasLength(error.getMessage())) {
+            return error.getMessage();
+        }
+
+        return "No message available";
+    }
+
+    private void addBindingResultErrorMessage(Map<String, Object> errorAttributes, BindingResult result) {
+        errorAttributes.put(
+                "message",
+                format(
+                        "Validation failed for object='%s'. Error count: %s",
+                        result.getObjectName(),
+                        result.getErrorCount()
+                )
+        );
+        errorAttributes.put("errors", result.getAllErrors());
+    }
+
+    private BindingResult extractBindingResult(Throwable error) {
+        if (error instanceof BindingResult) {
+            return (BindingResult) error;
+        }
+
+        return null;
+    }
+
+    private void addStackTrace(Map<String, Object> errorAttributes, Throwable error) {
+        StringWriter stackTrace = new StringWriter();
+
+        error.printStackTrace(new PrintWriter(stackTrace));
+        stackTrace.flush();
+        errorAttributes.put("trace", stackTrace.toString());
+    }
+
+    private void addPath(Map<String, Object> errorAttributes, RequestAttributes requestAttributes) {
+        String path = getAttribute(requestAttributes, ERROR_REQUEST_URI);
+
+        if (path != null) {
+            errorAttributes.put("path", path);
+        }
+    }
+
+    @Override
+    public Throwable getError(WebRequest webRequest) {
+        Throwable exception = getAttribute(webRequest, ERROR_INTERNAL_ATTRIBUTE);
+
+        if (exception == null) {
+            exception = getAttribute(webRequest, ERROR_EXCEPTION);
+        }
+
+        webRequest.setAttribute(ERROR_ATTRIBUTE, exception, SCOPE_REQUEST);
+
+        return exception;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getAttribute(RequestAttributes requestAttributes, String name) {
+        return (T) requestAttributes.getAttribute(name, SCOPE_REQUEST);
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/config/WebMvcConfiguration.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/config/WebMvcConfiguration.java
@@ -1,0 +1,16 @@
+package com.seeyouletter.api_member.config;
+
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    @Bean
+    public ErrorAttributes errorAttributes() {
+        return new CustomErrorAttributes();
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/exception/handler/DefaultErrorResponse.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/exception/handler/DefaultErrorResponse.java
@@ -1,0 +1,44 @@
+package com.seeyouletter.api_member.exception.handler;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static java.time.LocalDateTime.now;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Getter
+@RequiredArgsConstructor
+public class DefaultErrorResponse {
+
+    private final LocalDateTime timestamp = now();
+
+    private final int status;
+
+    private final String error;
+
+    private final String path;
+
+    private final String message;
+
+    public static DefaultErrorResponse badRequest(String path, String message) {
+        return new DefaultErrorResponse(
+                BAD_REQUEST.value(),
+                BAD_REQUEST.getReasonPhrase(),
+                path,
+                message
+        );
+    }
+
+    public static DefaultErrorResponse serverError(String path) {
+        return new DefaultErrorResponse(
+                INTERNAL_SERVER_ERROR.value(),
+                INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                path,
+                "서버 에러가 발생했습니다. 개발자에게 문의해주세요!"
+        );
+    }
+
+}

--- a/api-member/src/main/java/com/seeyouletter/api_member/exception/handler/DefaultExceptionHandler.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/exception/handler/DefaultExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.seeyouletter.api_member.exception.handler;
+
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static com.seeyouletter.api_member.exception.handler.DefaultErrorResponse.badRequest;
+import static com.seeyouletter.api_member.exception.handler.DefaultErrorResponse.serverError;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@RestControllerAdvice
+public class DefaultExceptionHandler {
+
+    @ExceptionHandler(value = Exception.class)
+    @ResponseStatus(code = INTERNAL_SERVER_ERROR)
+    public DefaultErrorResponse handle(HttpServletRequest request) {
+        return serverError(request.getRequestURI());
+    }
+
+    @ExceptionHandler(value = BindException.class)
+    @ResponseStatus(code = BAD_REQUEST)
+    public DefaultErrorResponse handle(BindException exception, HttpServletRequest request) {
+        String message = exception
+                .getAllErrors()
+                .get(0)
+                .getDefaultMessage();
+
+        return badRequest(request.getRequestURI(), message);
+    }
+
+}


### PR DESCRIPTION
## 💌 설명

- @Controller에서 발생하는 에러를 핸들링하는 전역 ExceptionHandler 추가
- @Controller에서 발생하지 않은 에러를 핸들링하는 ErrorController 구현체가 사용하는 ErrorAttributes의 커스텀 구현체를 추가하여 timestamp를 Date 타입에서 LocalDateTime으로 사용하도록 적용
- spring boot starter validation 의존성 추가

## 📎 관련 이슈

https://github.com/seeyouletter/docs/issues/9

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
