### PR TITLE
oauth2 authorization server 문서 오타 수정

### DIFF
--- a/api-member/src/docs/asciidoc/oauth2-authorization-server.adoc
+++ b/api-member/src/docs/asciidoc/oauth2-authorization-server.adoc
@@ -67,7 +67,7 @@ include::{snippets}/authorization/authorization/request-parameters.adoc[]
 === HTTP response
 include::{snippets}/authorization/authorization/http-response.adoc[]
 
-=== Request headers
+=== Response headers
 include::{snippets}/authorization/authorization/response-headers.adoc[]
 
 === Error Response
@@ -123,7 +123,7 @@ include::{snippets}/token/token/request-parameters.adoc[]
 === HTTP response
 include::{snippets}/token/token/http-response.adoc[]
 
-=== Request headers
+=== Response headers
 include::{snippets}/token/token/response-headers.adoc[]
 
 === Response fields
@@ -170,7 +170,7 @@ include::{snippets}/introspect/introspect/request-parameters.adoc[]
 === HTTP response
 include::{snippets}/introspect/introspect/http-response.adoc[]
 
-=== Request headers
+=== Response headers
 include::{snippets}/introspect/introspect/response-headers.adoc[]
 
 === Response fields
@@ -253,7 +253,7 @@ include::{snippets}/userinfo/userinfo/request-headers.adoc[]
 === HTTP response
 include::{snippets}/userinfo/userinfo/http-response.adoc[]
 
-=== Request headers
+=== Response headers
 include::{snippets}/userinfo/userinfo/response-headers.adoc[]
 
 === Response fields


### PR DESCRIPTION
## 💌 설명

- response header를 request header로 명시되어 있는 부분 수정

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [ ] 베이스가 제대로 적용되었나요?
- [ ] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
