### PR TITLE
에러 응답을 생성하는 전역 에러 핸들러 테스트 추가

### DIFF
--- a/api-member/src/main/java/com/seeyouletter/api_member/controller/DefaultController.java
+++ b/api-member/src/main/java/com/seeyouletter/api_member/controller/DefaultController.java
@@ -11,4 +11,9 @@ public class DefaultController {
         return "authorized";
     }
 
+    @GetMapping(value = "/")
+    public String index() {
+        return "";
+    }
+
 }

--- a/api-member/src/test/java/com/seeyouletter/api_member/exception/handler/DefaultExceptionHandlerTest.java
+++ b/api-member/src/test/java/com/seeyouletter/api_member/exception/handler/DefaultExceptionHandlerTest.java
@@ -1,0 +1,89 @@
+package com.seeyouletter.api_member.exception.handler;
+
+import com.seeyouletter.api_member.controller.DefaultController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.validation.BindException;
+import org.springframework.validation.ObjectError;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName(value = "전역 에러 핸들러 테스트")
+@WithMockUser
+@ExtendWith(value = MockitoExtension.class)
+@WebMvcTest(controllers = DefaultController.class)
+class DefaultExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DefaultController defaultController;
+
+    @DisplayName(value = "500 에러 핸들링")
+    @Test
+    void handleInternalServerError() throws Exception {
+        when(defaultController.index()).thenThrow(new RuntimeException());
+
+        mockMvc.perform(get("/"))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.status").value(INTERNAL_SERVER_ERROR.value()))
+                .andExpect(jsonPath("$.error").value(INTERNAL_SERVER_ERROR.getReasonPhrase()))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @DisplayName(value = "400 에러 핸들링")
+    @Test
+    void handleBadRequest() throws Exception {
+        BindException bindException = mock(BindException.class);
+        ObjectError objectError = mock(ObjectError.class);
+        String defaultMessage = "테스트 에러 발생";
+
+        when(bindException.getAllErrors()).thenReturn(List.of(objectError));
+        when(objectError.getDefaultMessage()).thenReturn(defaultMessage);
+
+
+        when(defaultController.index()).thenAnswer(i -> {
+            throw bindException;
+        });
+
+        mockMvc.perform(get("/"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.error").value(BAD_REQUEST.getReasonPhrase()))
+                .andExpect(jsonPath("$.message").value(defaultMessage));
+    }
+
+    @DisplayName(value = "예외가 발생하지 않은 경우는 예외 핸들링 제외")
+    @Test
+    void doNotHandleWhenNotThrowException() throws Exception {
+        mockMvc.perform(get("/"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.timestamp").doesNotExist())
+                .andExpect(jsonPath("$.status").doesNotExist())
+                .andExpect(jsonPath("$.error").doesNotExist())
+                .andExpect(jsonPath("$.message").doesNotExist());
+    }
+
+}


### PR DESCRIPTION
## 💌 설명

- 에러 응답을 생성하는 전역 에러 핸들러 테스트 추가

## 📎 관련 이슈

<!--`github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉-->

## 💡 논의해볼 사항

<!--
PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!

예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭
-->

## 📝 참고자료

<!-- 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부) -->

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
